### PR TITLE
Generic Request Body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_requests"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Code generated request types for the Elasticsearch REST API."

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -16,22 +16,11 @@ fn new_req(b: &mut Bencher) {
 }
 
 #[bench]
-fn ref_req_into_http_req(b: &mut Bencher) {
-	let req = SearchRequest::for_index_ty("test_index", "test_ty", "{'query': { 'match_all': {}}}");
-
-	b.iter(|| {
-		let http_req: HttpRequest = (&req).into();
-
-		test::black_box(http_req)
-	});
-}
-
-#[bench]
 fn owned_req_into_http_req(b: &mut Bencher) {
 	b.iter(|| {
 		let req = SearchRequest::for_index_ty("test_index", "test_ty", "{'query': { 'match_all': {}}}");
 
-		let http_req: HttpRequest = (req).into();
+		let http_req: HttpRequest<_> = (req).into();
 
 		test::black_box(http_req)
 	});

--- a/codegen/src/gen/mod.rs
+++ b/codegen/src/gen/mod.rs
@@ -25,6 +25,7 @@ pub mod types {
             let url = ty();
 
             quote!(
+                /// A wrapper around an owned or borrowed url.
                 pub struct #url(Cow<'a, str>);
 
                 impl <'a> From<&'a str> for #url {
@@ -59,54 +60,28 @@ pub mod types {
         use ::gen::helpers;
 
         pub fn ident() -> &'static str {
-            "Body"
-        }
-
-        pub fn generic_ident() -> &'static str {
-            "R"
+            "B"
         }
 
         pub fn default_ident() -> &'static str {
             "DefaultBody"
         }
 
-        pub fn ty(body_generic: syn::Ty) -> syn::Ty {
-            helpers::ty_path(ident(), vec![], vec![body_generic])
+        pub fn ty() -> syn::Ty {
+            helpers::ty(ident())
         }
 
         pub fn tokens() -> quote::Tokens {
-            let body_generic = helpers::ty(generic_ident());
-            let body = ty(body_generic.clone());
-            let body_no_generic = helpers::ty(ident());
             let default_body = helpers::ident(default_ident());
 
             quote!(
-                pub struct #body(#body_generic);
-
+                /// A default body type.
                 pub type #default_body = &'static [u8];
 
-                impl<#body_generic> #body {
-                    pub fn new(inner: #body_generic) -> Self {
-                        #body_no_generic(inner)
-                    }
-
-                    pub fn into_inner(self) -> #body_generic {
-                        self.0
-                    }
-                }
-
-                impl #body_no_generic<#default_body> {
-                    pub fn none() -> Self {
-                        Body(&[])
-                    }
-                }
-
-                impl <#body_generic> AsRef<[u8]> for #body 
-                    where #body_generic: AsRef<[u8]>
-                {
-                    fn as_ref(&self) -> &[u8] {
-                        self.0.as_ref()
-                    }
+                /// A convenience method for a default, empty body.
+                /// This method doesn't allocate.
+                pub fn empty_body() -> #default_body {
+                    &[]
                 }
             )
         }
@@ -133,6 +108,7 @@ pub mod types {
             let method_ty = method_ty();
 
             helpers::parse_item(quote!(
+                /// A standard HTTP verb.
                 pub enum #method_ty {
                     Head,
                     Get,
@@ -159,11 +135,11 @@ pub mod types {
 
             let url_ty = url::ty();
 
-            let body_generic_ty = helpers::ty(body::generic_ident());
-            let body_ty = body::ty(body_generic_ty.clone());
+            let body_ty = body::ty();
 
             quote!(
-                pub struct #request_ty<'a, #body_generic_ty> {
+                /// A general request type that all endpoints can be converted into.
+                pub struct #request_ty<'a, #body_ty> {
                     pub url: #url_ty,
                     pub method: #method_ty,
                     pub body: Option<#body_ty>

--- a/codegen/src/gen/mod.rs
+++ b/codegen/src/gen/mod.rs
@@ -83,11 +83,11 @@ pub mod types {
             quote!(
                 pub struct #body(#body_generic);
 
-                pub #default_body = &'static [u8];
+                pub type #default_body = &'static [u8];
 
                 impl<#body_generic> #body {
                     pub fn new(inner: #body_generic) -> Self {
-                        #body(inner)
+                        #body_no_generic(inner)
                     }
 
                     pub fn into_inner(self) -> #body_generic {
@@ -95,9 +95,17 @@ pub mod types {
                     }
                 }
 
-                impl #body_no_generic<&'static [u8]> {
+                impl #body_no_generic<#default_body> {
                     pub fn none() -> Self {
                         Body(&[])
+                    }
+                }
+
+                impl <#body_generic> AsRef<[u8]> for #body 
+                    where #body_generic: AsRef<[u8]>
+                {
+                    fn as_ref(&self) -> &[u8] {
+                        self.0.as_ref()
                     }
                 }
             )
@@ -155,7 +163,7 @@ pub mod types {
             let body_ty = body::ty(body_generic_ty.clone());
 
             quote!(
-                pub struct #request_ty<#body_generic_ty> {
+                pub struct #request_ty<'a, #body_generic_ty> {
                     pub url: #url_ty,
                     pub method: #method_ty,
                     pub body: Option<#body_ty>

--- a/codegen/src/gen/request_ctors.rs
+++ b/codegen/src/gen/request_ctors.rs
@@ -391,13 +391,11 @@ pub mod tests {
             .build();
 
         let expected = quote!(
-            impl <'a> Request<'a> {
-                pub fn new<IBody>(body: IBody) -> Request<'a> 
-                    where IBody: Into<Body<'a> >
-                {
+            impl <'a, R> Request<'a, R> {
+                pub fn new(body: R) -> Self {
                     Request {
                         url: UrlParams::None.url(),
-                        body: body.into()
+                        body: Body::new(body)
                     }
                 }
             }
@@ -417,16 +415,15 @@ pub mod tests {
             .build();
 
         let expected = quote!(
-            impl <'a> Request<'a> {
-                pub fn for_index_ty_id<IIndex, IType, IId, IBody>(index: IIndex, ty: IType, id: IId, body: IBody) -> Request<'a> 
+            impl <'a, R> Request<'a, R> {
+                pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex, ty: IType, id: IId, body: R) -> Self 
                     where IIndex: Into<Index<'a> >,
                           IType: Into<Type<'a> >,
-                          IId: Into<Id<'a> >,
-                          IBody: Into<Body<'a> >
+                          IId: Into<Id<'a> >
                 {
                     Request {
                         url: UrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                        body: body.into()
+                        body: Body::new(body)
                     }
                 }
             }
@@ -454,34 +451,30 @@ pub mod tests {
         let result = RequestParamsCtorBuilder::from((&endpoint, &req_ty, &url_params)).build();
 
         let expected = quote!(
-            impl <'a> IndicesExistsAliasRequest <'a> { 
-                pub fn new<IBody>(body: IBody) -> IndicesExistsAliasRequest<'a> 
-                    where IBody: Into<Body<'a> >
-                { 
+            impl <'a, R> IndicesExistsAliasRequest <'a, R> { 
+                pub fn new(body: R) -> Self { 
                     IndicesExistsAliasRequest { 
                         url : IndicesExistsAliasUrlParams::None.url(),
-                        body: body.into()
+                        body: Body::new(body)
                     }
                 }
 
-                pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesExistsAliasRequest<'a> 
-                    where IIndex: Into<Index<'a> >,
-                          IBody: Into<Body<'a> >
+                pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+                    where IIndex: Into<Index<'a> >
                 { 
                     IndicesExistsAliasRequest { 
                         url : IndicesExistsAliasUrlParams::Index(index.into()).url(),
-                        body: body.into()
+                        body: Body::new(body)
                     }
                 }
 
-                pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex, ty: IType, body: IBody) -> IndicesExistsAliasRequest<'a> 
+                pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
                     where IIndex: Into<Index<'a> >,
-                          IType: Into<Type<'a> >,
-                          IBody: Into<Body<'a> >
+                          IType: Into<Type<'a> >
                 { 
                     IndicesExistsAliasRequest { 
                         url : IndicesExistsAliasUrlParams::IndexType(index.into(), ty.into()).url(),
-                        body: body.into()
+                        body: Body::new(body)
                     }
                 }
             }

--- a/codegen/src/gen/request_ctors.rs
+++ b/codegen/src/gen/request_ctors.rs
@@ -90,7 +90,7 @@ impl RequestParamsCtorBuilder {
     /// a body field.
     fn body_field(has_body: bool) -> Option<(syn::Ident, syn::Ty)> {
         if has_body {
-            Some((ident("body"), types::body::ty(ty(types::body::generic_ident()))))
+            Some((ident("body"), types::body::ty()))
         } else {
             None
         }
@@ -180,9 +180,7 @@ impl RequestParamsCtorBuilder {
             fields.push(syn::FieldValue {
                 attrs: vec![],
                 ident: ident("body"),
-                expr: syn::ExprKind::Call(Box::new(syn::ExprKind::Path(None, path_segments(vec![(types::body::ident(), vec![], vec![]), 
-                                                                                                ("new", vec![], vec![])])).into()), 
-                                          vec![syn::ExprKind::Path(None, path_none(body_ident.as_ref())).into()]).into(),
+                expr: syn::ExprKind::Path(None, path_none(body_ident.as_ref())).into(),
                 is_shorthand: false,
             });
         }
@@ -210,12 +208,12 @@ impl RequestParamsCtorBuilder {
             })
             .collect();
 
-        // Body arg: `body: R`.
+        // Body arg: `body: B`.
         if let Some(ref body) = ctor.body_field {
             args.push({
                 let (ref name, _) = *body;
 
-                syn::FnArg::Captured(syn::Pat::Path(None, path_none(&name.to_string())), ty(types::body::generic_ident()))
+                syn::FnArg::Captured(syn::Pat::Path(None, path_none(&name.to_string())), types::body::ty())
             });
         }
 
@@ -398,17 +396,17 @@ pub mod tests {
 
     #[test]
     fn gen_request_ctor_body() {
-        let req_ty = ty_path("Request", vec![lifetime()], vec![ty(types::body::generic_ident())]);
+        let req_ty = ty_path("Request", vec![lifetime()], vec![types::body::ty()]);
         let result = RequestParamsCtorBuilder::new(true, req_ty, ty_a("UrlParams"))
             .with_constructor(vec![])
             .build();
 
         let expected = quote!(
-            impl <'a, R> Request<'a, R> {
-                pub fn new(body: R) -> Self {
+            impl <'a, B> Request<'a, B> {
+                pub fn new(body: B) -> Self {
                     Request {
                         url: UrlParams::None.url(),
-                        body: Body::new(body)
+                        body: body
                     }
                 }
             }
@@ -419,7 +417,7 @@ pub mod tests {
 
     #[test]
     fn gen_request_ctor_params_body() {
-        let req_ty = ty_path("Request", vec![lifetime()], vec![ty(types::body::generic_ident())]);
+        let req_ty = ty_path("Request", vec![lifetime()], vec![types::body::ty()]);
         let result = RequestParamsCtorBuilder::new(true, req_ty, ty_a("UrlParams"))
             .with_constructor(vec![
                 "Index".into(),
@@ -429,15 +427,15 @@ pub mod tests {
             .build();
 
         let expected = quote!(
-            impl <'a, R> Request<'a, R> {
-                pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex, ty: IType, id: IId, body: R) -> Self 
+            impl <'a, B> Request<'a, B> {
+                pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex, ty: IType, id: IId, body: B) -> Self 
                     where IIndex: Into<Index<'a> >,
                           IType: Into<Type<'a> >,
                           IId: Into<Id<'a> >
                 {
                     Request {
                         url: UrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                        body: Body::new(body)
+                        body: body
                     }
                 }
             }
@@ -459,36 +457,36 @@ pub mod tests {
             body: Some(Body { description: String::new() }),
         });
 
-        let req_ty = ty_path("IndicesExistsAliasRequest", vec![lifetime()], vec![ty(types::body::generic_ident())]);
+        let req_ty = ty_path("IndicesExistsAliasRequest", vec![lifetime()], vec![types::body::ty()]);
         let url_params = UrlParamBuilder::from(&endpoint).build();
 
         let result = RequestParamsCtorBuilder::from((&endpoint, &req_ty, &url_params)).build();
 
         let expected = quote!(
-            impl <'a, R> IndicesExistsAliasRequest <'a, R> { 
-                pub fn new(body: R) -> Self { 
+            impl <'a, B> IndicesExistsAliasRequest <'a, B> { 
+                pub fn new(body: B) -> Self { 
                     IndicesExistsAliasRequest { 
                         url : IndicesExistsAliasUrlParams::None.url(),
-                        body: Body::new(body)
+                        body: body
                     }
                 }
 
-                pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+                pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
                     where IIndex: Into<Index<'a> >
                 { 
                     IndicesExistsAliasRequest { 
                         url : IndicesExistsAliasUrlParams::Index(index.into()).url(),
-                        body: Body::new(body)
+                        body: body
                     }
                 }
 
-                pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+                pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
                     where IIndex: Into<Index<'a> >,
                           IType: Into<Type<'a> >
                 { 
                     IndicesExistsAliasRequest { 
                         url : IndicesExistsAliasUrlParams::IndexType(index.into(), ty.into()).url(),
-                        body: Body::new(body)
+                        body: body
                     }
                 }
             }

--- a/codegen/src/gen/request_ctors.rs
+++ b/codegen/src/gen/request_ctors.rs
@@ -331,7 +331,7 @@ pub mod tests {
 
     #[test]
     fn gen_request_ctor_none() {
-        let req_ty = ty_path("Request", vec![lifetime()], vec![ty(types::body::generic_ident())]);
+        let req_ty = ty_a("Request");
         let result = RequestParamsCtorBuilder::new(false, req_ty, ty_a("UrlParams"))
             .with_constructor(vec![])
             .build();
@@ -351,7 +351,7 @@ pub mod tests {
 
     #[test]
     fn gen_request_ctor_params() {
-        let req_ty = ty_path("Request", vec![lifetime()], vec![ty(types::body::generic_ident())]);
+        let req_ty = ty_a("Request");
         let result = RequestParamsCtorBuilder::new(false, req_ty, ty_a("UrlParams"))
             .with_constructor(vec![
                 "Index".into(),

--- a/codegen/src/gen/request_into_http.rs
+++ b/codegen/src/gen/request_into_http.rs
@@ -105,18 +105,8 @@ mod tests {
         let result = RequestIntoHttpRequestBuilder::from((&endpoint, &req_ty)).build();
 
         let expected = quote!(
-            impl <'a, 'b: 'a> Into<HttpRequest<'a> > for &'a IndicesExistsAliasRequest<'b> {
-                fn into(self) -> HttpRequest<'a> {
-                    HttpRequest {
-                        url: self.url.as_ref().into(),
-                        method: HttpMethod::Get,
-                        body: Some(self.body.as_ref().into())
-                    }
-                }
-            }
-
-            impl <'a> Into<HttpRequest<'a> > for IndicesExistsAliasRequest<'a> {
-                fn into(self) -> HttpRequest<'a> {
+            impl <'a, R> Into<HttpRequest<'a, R> > for IndicesExistsAliasRequest<'a, R> {
+                fn into(self) -> HttpRequest<'a, R> {
                     HttpRequest {
                         url: self.url,
                         method: HttpMethod::Get,

--- a/codegen/src/gen/request_into_http.rs
+++ b/codegen/src/gen/request_into_http.rs
@@ -32,7 +32,7 @@ impl RequestIntoHttpRequestBuilder {
         };
 
         if self.has_body {
-            let generic_body = ident(types::body::generic_ident());
+            let generic_body = ident(types::body::ident());
             quote!(
                 impl <'a, #generic_body> Into<HttpRequest<'a, #generic_body> > for #req_ty {
                     fn into(self) -> HttpRequest<'a, #generic_body> {
@@ -88,13 +88,13 @@ mod tests {
             url: get_url(),
             body: Some(Body { description: String::new() }),
         });
-        let req_ty = ty_path("Request", vec![lifetime()], vec![ty(::gen::types::body::generic_ident())]);
+        let req_ty = ty_path("Request", vec![lifetime()], vec![types::body::ty()]);
 
         let result = RequestIntoHttpRequestBuilder::from((&endpoint, &req_ty)).build();
 
         let expected = quote!(
-            impl <'a, R> Into<HttpRequest<'a, R> > for Request<'a, R> {
-                fn into(self) -> HttpRequest<'a, R> {
+            impl <'a, B> Into<HttpRequest<'a, B> > for Request<'a, B> {
+                fn into(self) -> HttpRequest<'a, B> {
                     HttpRequest {
                         url: self.url,
                         method: HttpMethod::Get,

--- a/codegen/src/gen/request_params.rs
+++ b/codegen/src/gen/request_params.rs
@@ -74,8 +74,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn gen_request_params_ty() {
+    fn gen_request_params_ty_no_body() {
         let (_, result) = RequestParamBuilder::new("Request").build();
+
+        let expected = quote!(Request<'a>);
+
+        ast_eq(expected, result);
+    }
+
+    #[test]
+    fn gen_request_params_no_body() {
+        let (result, _) = RequestParamBuilder::new("Request").build();
+
+        let expected = quote!(
+            pub struct Request<'a> {
+                pub url: Url<'a>
+            }
+        );
+
+        ast_eq(expected, result.into_stmt());
+    }
+
+    #[test]
+    fn gen_request_params_ty_with_body() {
+        let (_, result) = RequestParamBuilder::new("Request").has_body(true).build();
 
         let expected = quote!(Request<'a, R>);
 
@@ -83,12 +105,13 @@ mod tests {
     }
 
     #[test]
-    fn gen_request_params() {
-        let (result, _) = RequestParamBuilder::new("Request").build();
+    fn gen_request_params_with_body() {
+        let (result, _) = RequestParamBuilder::new("Request").has_body(true).build();
 
         let expected = quote!(
             pub struct Request<'a, R> {
-                pub url: Url<'a>
+                pub url: Url<'a>,
+                pub body: Body<R>,
             }
         );
 

--- a/codegen/src/gen/request_params.rs
+++ b/codegen/src/gen/request_params.rs
@@ -36,11 +36,13 @@ impl RequestParamBuilder {
                 ident: Some(ident("body")),
                 vis: syn::Visibility::Public,
                 attrs: vec![],
-                ty: types::body::ty(),
+                ty: types::body::ty(ty(types::body::generic_ident())),
             });
         }
 
         let fields = syn::VariantData::Struct(fields);
+
+        let generics = generics(vec![lifetime()], vec![ty_param(types::body::generic_ident(), vec![])]);
 
         let ty = ty_a(self.name.as_ref());
 
@@ -48,7 +50,7 @@ impl RequestParamBuilder {
             ident: self.name,
             vis: syn::Visibility::Public,
             attrs: vec![],
-            node: syn::ItemKind::Struct(fields, generics_a()),
+            node: syn::ItemKind::Struct(fields, generics),
         };
 
         (item, ty)
@@ -75,7 +77,7 @@ mod tests {
     fn gen_request_params_ty() {
         let (_, result) = RequestParamBuilder::new("Request").build();
 
-        let expected = quote!(Request<'a>);
+        let expected = quote!(Request<'a, R>);
 
         ast_eq(expected, result);
     }
@@ -85,7 +87,7 @@ mod tests {
         let (result, _) = RequestParamBuilder::new("Request").build();
 
         let expected = quote!(
-            pub struct Request<'a> {
+            pub struct Request<'a, R> {
                 pub url: Url<'a>
             }
         );
@@ -108,9 +110,9 @@ mod tests {
         let (result, _) = RequestParamBuilder::from(&endpoint).build();
 
         let expected = quote!(
-            pub struct IndicesExistsAliasRequest<'a> {
+            pub struct IndicesExistsAliasRequest<'a, R> {
                 pub url: Url<'a>,
-                pub body: Body<'a>
+                pub body: Body<R>
             }
         );
 

--- a/codegen/src/gen/request_params.rs
+++ b/codegen/src/gen/request_params.rs
@@ -38,10 +38,10 @@ impl RequestParamBuilder {
                 ident: Some(ident("body")),
                 vis: syn::Visibility::Public,
                 attrs: vec![],
-                ty: types::body::ty(ty(types::body::generic_ident())),
+                ty: types::body::ty(),
             });
 
-            generics.ty_params.push(ty_param(types::body::generic_ident(), vec![]));
+            generics.ty_params.push(ty_param(types::body::ident(), vec![]));
         }
 
         let fields = syn::VariantData::Struct(fields);
@@ -109,7 +109,7 @@ mod tests {
     fn gen_request_params_ty_with_body() {
         let (_, result) = RequestParamBuilder::new("Request").has_body(true).build();
 
-        let expected = quote!(Request<'a, R>);
+        let expected = quote!(Request<'a, B>);
 
         ast_eq(expected, result);
     }
@@ -119,9 +119,9 @@ mod tests {
         let (result, _) = RequestParamBuilder::new("Request").has_body(true).build();
 
         let expected = quote!(
-            pub struct Request<'a, R> {
+            pub struct Request<'a, B> {
                 pub url: Url<'a>,
-                pub body: Body<R>
+                pub body: B
             }
         );
 
@@ -143,9 +143,9 @@ mod tests {
         let (result, _) = RequestParamBuilder::from(&endpoint).build();
 
         let expected = quote!(
-            pub struct IndicesExistsAliasRequest<'a, R> {
+            pub struct IndicesExistsAliasRequest<'a, B> {
                 pub url: Url<'a>,
-                pub body: Body<R>
+                pub body: B
             }
         );
 

--- a/codegen/src/gen/url_builder.rs
+++ b/codegen/src/gen/url_builder.rs
@@ -76,7 +76,7 @@ impl UrlParamMatchBuilder {
     }
 
     pub fn build(self) -> syn::Expr {
-        let to_match = path("self").into_expr();
+        let to_match = path_none("self").into_expr();
 
         syn::ExprKind::Match(Box::new(to_match), self.arms).into()
     }
@@ -181,7 +181,7 @@ impl<'a> UrlReplaceBuilder<'a> {
                 PathPart::Param(p) => {
                     Some(syn::ExprKind::MethodCall(ident("len"),
                                                    vec![],
-                                                   vec![syn::ExprKind::Path(None, path(p)).into()])
+                                                   vec![syn::ExprKind::Path(None, path_none(p)).into()])
                         .into())
                 }
                 _ => None,
@@ -208,7 +208,7 @@ impl<'a> UrlReplaceBuilder<'a> {
     /// Get a statement to build a `String` with a capacity of the given expression.
     fn let_url_stmt(url_ident: syn::Ident, len_expr: syn::Expr) -> syn::Stmt {
         let string_with_capacity = syn::ExprKind::Call(Box::new(syn::ExprKind::Path(None, {
-                                                               let mut method = path("String");
+                                                               let mut method = path_none("String");
                                                                method.segments.push(syn::PathSegment::from("with_capacity"));
                                                                method
                                                            })
@@ -290,10 +290,10 @@ impl UrlMethodBuilder {
 
         let (generics, fngenerics) = {
             if self.params_ty.has_lifetime() {
-                (generics_a(), generics())
+                (generics_a(), generics_none())
             }
             else {
-                (generics(), generics_a())
+                (generics_none(), generics_a())
             }
         };
 

--- a/codegen/src/gen/url_params.rs
+++ b/codegen/src/gen/url_params.rs
@@ -89,7 +89,7 @@ impl UrlParamBuilder {
                 (ty_a(self.name.as_ref()), generics_a())
             }
             else {
-                (ty(self.name.as_ref()), generics())
+                (ty(self.name.as_ref()), generics_none())
             }
         };
 

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -218,6 +218,7 @@ fn endpoints_mod(tokens: &mut Tokens, derives: Tokens, http_mod: &'static str, e
 
 fn http_mod(tokens: &mut Tokens, derives: Tokens) {
     let url_tokens = gen::types::url::tokens();
+
     let body_tokens = gen::types::body::tokens();
     let http_method_item = gen::types::request::method_item();
     let http_req_item = gen::types::request::req_tokens();
@@ -233,8 +234,7 @@ fn http_mod(tokens: &mut Tokens, derives: Tokens) {
 
     tokens.append_all(vec![
         derives.clone(),
-        url_tokens, 
-        derives.clone(),
+        url_tokens,
         body_tokens, 
         derives.clone(),
         http_req_item, 

--- a/src/genned.rs
+++ b/src/genned.rs
@@ -22,22 +22,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesCloseRequest<'a, R> {
+    pub struct IndicesCloseRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesCloseRequest<'a, R> {
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+    impl<'a, B> IndicesCloseRequest<'a, B> {
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesCloseRequest {
                 url: IndicesCloseUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesCloseRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesCloseRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -117,24 +117,24 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct TermvectorsRequest<'a, R> {
+    pub struct TermvectorsRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> TermvectorsRequest<'a, R> {
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+    impl<'a, B> TermvectorsRequest<'a, B> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             TermvectorsRequest {
                 url: TermvectorsUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
         pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
                                                    ty: IType,
                                                    id: IId,
-                                                   body: R)
+                                                   body: B)
                                                    -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
@@ -142,12 +142,12 @@ pub mod endpoints {
         {
             TermvectorsRequest {
                 url: TermvectorsUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for TermvectorsRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for TermvectorsRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -175,28 +175,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct FieldStatsRequest<'a, R> {
+    pub struct FieldStatsRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> FieldStatsRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> FieldStatsRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             FieldStatsRequest {
                 url: FieldStatsUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             FieldStatsRequest {
                 url: FieldStatsUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for FieldStatsRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for FieldStatsRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -386,15 +386,15 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct CreateRequest<'a, R> {
+    pub struct CreateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> CreateRequest<'a, R> {
+    impl<'a, B> CreateRequest<'a, B> {
         pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
                                                    ty: IType,
                                                    id: IId,
-                                                   body: R)
+                                                   body: B)
                                                    -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
@@ -402,12 +402,12 @@ pub mod endpoints {
         {
             CreateRequest {
                 url: CreateUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for CreateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for CreateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -465,20 +465,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ClusterAllocationExplainRequest<'a, R> {
+    pub struct ClusterAllocationExplainRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> ClusterAllocationExplainRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> ClusterAllocationExplainRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             ClusterAllocationExplainRequest {
                 url: ClusterAllocationExplainUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for ClusterAllocationExplainRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for ClusterAllocationExplainRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -503,22 +503,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesPutTemplateRequest<'a, R> {
+    pub struct IndicesPutTemplateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesPutTemplateRequest<'a, R> {
-        pub fn for_name<IName>(name: IName, body: R) -> Self
+    impl<'a, B> IndicesPutTemplateRequest<'a, B> {
+        pub fn for_name<IName>(name: IName, body: B) -> Self
             where IName: Into<Name<'a>>
         {
             IndicesPutTemplateRequest {
                 url: IndicesPutTemplateUrlParams::Name(name.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesPutTemplateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesPutTemplateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -655,37 +655,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MsearchTemplateRequest<'a, R> {
+    pub struct MsearchTemplateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> MsearchTemplateRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> MsearchTemplateRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             MsearchTemplateRequest {
                 url: MsearchTemplateUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             MsearchTemplateRequest {
                 url: MsearchTemplateUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             MsearchTemplateRequest {
                 url: MsearchTemplateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for MsearchTemplateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for MsearchTemplateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -723,37 +723,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct BulkRequest<'a, R> {
+    pub struct BulkRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> BulkRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> BulkRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             BulkRequest {
                 url: BulkUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             BulkRequest {
                 url: BulkUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             BulkRequest {
                 url: BulkUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for BulkRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for BulkRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -784,15 +784,15 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ExplainRequest<'a, R> {
+    pub struct ExplainRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> ExplainRequest<'a, R> {
+    impl<'a, B> ExplainRequest<'a, B> {
         pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
                                                    ty: IType,
                                                    id: IId,
-                                                   body: R)
+                                                   body: B)
                                                    -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
@@ -800,12 +800,12 @@ pub mod endpoints {
         {
             ExplainRequest {
                 url: ExplainUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for ExplainRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for ExplainRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -833,28 +833,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SuggestRequest<'a, R> {
+    pub struct SuggestRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> SuggestRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> SuggestRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             SuggestRequest {
                 url: SuggestUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             SuggestRequest {
                 url: SuggestUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for SuggestRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for SuggestRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -924,28 +924,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct RenderSearchTemplateRequest<'a, R> {
+    pub struct RenderSearchTemplateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> RenderSearchTemplateRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> RenderSearchTemplateRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             RenderSearchTemplateRequest {
                 url: RenderSearchTemplateUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_id<IId>(id: IId, body: R) -> Self
+        pub fn for_id<IId>(id: IId, body: B) -> Self
             where IId: Into<Id<'a>>
         {
             RenderSearchTemplateRequest {
                 url: RenderSearchTemplateUrlParams::Id(id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for RenderSearchTemplateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for RenderSearchTemplateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1073,28 +1073,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesForcemergeRequest<'a, R> {
+    pub struct IndicesForcemergeRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesForcemergeRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesForcemergeRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesForcemergeRequest {
                 url: IndicesForcemergeUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesForcemergeRequest {
                 url: IndicesForcemergeUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesForcemergeRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesForcemergeRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1223,28 +1223,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesFlushSyncedRequest<'a, R> {
+    pub struct IndicesFlushSyncedRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesFlushSyncedRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesFlushSyncedRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesFlushSyncedRequest {
                 url: IndicesFlushSyncedUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesFlushSyncedRequest {
                 url: IndicesFlushSyncedUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesFlushSyncedRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesFlushSyncedRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1282,37 +1282,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MsearchRequest<'a, R> {
+    pub struct MsearchRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> MsearchRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> MsearchRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             MsearchRequest {
                 url: MsearchUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             MsearchRequest {
                 url: MsearchUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             MsearchRequest {
                 url: MsearchUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for MsearchRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for MsearchRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1379,37 +1379,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SearchTemplateRequest<'a, R> {
+    pub struct SearchTemplateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> SearchTemplateRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> SearchTemplateRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             SearchTemplateRequest {
                 url: SearchTemplateUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             SearchTemplateRequest {
                 url: SearchTemplateUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             SearchTemplateRequest {
                 url: SearchTemplateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for SearchTemplateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for SearchTemplateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1481,31 +1481,31 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct DeleteByQueryRequest<'a, R> {
+    pub struct DeleteByQueryRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> DeleteByQueryRequest<'a, R> {
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+    impl<'a, B> DeleteByQueryRequest<'a, B> {
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             DeleteByQueryRequest {
                 url: DeleteByQueryUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             DeleteByQueryRequest {
                 url: DeleteByQueryUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for DeleteByQueryRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for DeleteByQueryRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1566,22 +1566,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesCreateRequest<'a, R> {
+    pub struct IndicesCreateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesCreateRequest<'a, R> {
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+    impl<'a, B> IndicesCreateRequest<'a, B> {
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesCreateRequest {
                 url: IndicesCreateUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesCreateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesCreateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Put,
@@ -1622,24 +1622,24 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct PercolateRequest<'a, R> {
+    pub struct PercolateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> PercolateRequest<'a, R> {
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+    impl<'a, B> PercolateRequest<'a, B> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             PercolateRequest {
                 url: PercolateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
         pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
                                                    ty: IType,
                                                    id: IId,
-                                                   body: R)
+                                                   body: B)
                                                    -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
@@ -1647,12 +1647,12 @@ pub mod endpoints {
         {
             PercolateRequest {
                 url: PercolateUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for PercolateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for PercolateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1690,37 +1690,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SearchRequest<'a, R> {
+    pub struct SearchRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> SearchRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> SearchRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             SearchRequest {
                 url: SearchUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             SearchRequest {
                 url: SearchUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             SearchRequest {
                 url: SearchUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for SearchRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for SearchRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1775,22 +1775,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SnapshotVerifyRepositoryRequest<'a, R> {
+    pub struct SnapshotVerifyRepositoryRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> SnapshotVerifyRepositoryRequest<'a, R> {
-        pub fn for_repository<IRepository>(repository: IRepository, body: R) -> Self
+    impl<'a, B> SnapshotVerifyRepositoryRequest<'a, B> {
+        pub fn for_repository<IRepository>(repository: IRepository, body: B) -> Self
             where IRepository: Into<Repository<'a>>
         {
             SnapshotVerifyRepositoryRequest {
                 url: SnapshotVerifyRepositoryUrlParams::Repository(repository.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for SnapshotVerifyRepositoryRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for SnapshotVerifyRepositoryRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1828,37 +1828,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct CountRequest<'a, R> {
+    pub struct CountRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> CountRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> CountRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             CountRequest {
                 url: CountUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             CountRequest {
                 url: CountUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             CountRequest {
                 url: CountUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for CountRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for CountRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1927,28 +1927,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesFlushRequest<'a, R> {
+    pub struct IndicesFlushRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesFlushRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesFlushRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesFlushRequest {
                 url: IndicesFlushUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesFlushRequest {
                 url: IndicesFlushUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesFlushRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesFlushRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1976,28 +1976,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesRefreshRequest<'a, R> {
+    pub struct IndicesRefreshRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesRefreshRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesRefreshRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesRefreshRequest {
                 url: IndicesRefreshUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesRefreshRequest {
                 url: IndicesRefreshUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesRefreshRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesRefreshRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2054,28 +2054,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SearchShardsRequest<'a, R> {
+    pub struct SearchShardsRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> SearchShardsRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> SearchShardsRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             SearchShardsRequest {
                 url: SearchShardsUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             SearchShardsRequest {
                 url: SearchShardsUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for SearchShardsRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for SearchShardsRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2309,22 +2309,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IngestPutPipelineRequest<'a, R> {
+    pub struct IngestPutPipelineRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IngestPutPipelineRequest<'a, R> {
-        pub fn for_id<IId>(id: IId, body: R) -> Self
+    impl<'a, B> IngestPutPipelineRequest<'a, B> {
+        pub fn for_id<IId>(id: IId, body: B) -> Self
             where IId: Into<Id<'a>>
         {
             IngestPutPipelineRequest {
                 url: IngestPutPipelineUrlParams::Id(id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IngestPutPipelineRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IngestPutPipelineRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Put,
@@ -2381,28 +2381,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IngestSimulateRequest<'a, R> {
+    pub struct IngestSimulateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IngestSimulateRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IngestSimulateRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IngestSimulateRequest {
                 url: IngestSimulateUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_id<IId>(id: IId, body: R) -> Self
+        pub fn for_id<IId>(id: IId, body: B) -> Self
             where IId: Into<Id<'a>>
         {
             IngestSimulateRequest {
                 url: IngestSimulateUrlParams::Id(id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IngestSimulateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IngestSimulateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2618,28 +2618,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct TasksCancelRequest<'a, R> {
+    pub struct TasksCancelRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> TasksCancelRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> TasksCancelRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             TasksCancelRequest {
                 url: TasksCancelUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_task_id<ITaskId>(task_id: ITaskId, body: R) -> Self
+        pub fn for_task_id<ITaskId>(task_id: ITaskId, body: B) -> Self
             where ITaskId: Into<TaskId<'a>>
         {
             TasksCancelRequest {
                 url: TasksCancelUrlParams::TaskId(task_id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for TasksCancelRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for TasksCancelRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2667,28 +2667,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesClearCacheRequest<'a, R> {
+    pub struct IndicesClearCacheRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesClearCacheRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesClearCacheRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesClearCacheRequest {
                 url: IndicesClearCacheUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesClearCacheRequest {
                 url: IndicesClearCacheUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesClearCacheRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesClearCacheRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2766,31 +2766,31 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesPutMappingRequest<'a, R> {
+    pub struct IndicesPutMappingRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesPutMappingRequest<'a, R> {
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+    impl<'a, B> IndicesPutMappingRequest<'a, B> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             IndicesPutMappingRequest {
                 url: IndicesPutMappingUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_ty<IType>(ty: IType, body: R) -> Self
+        pub fn for_ty<IType>(ty: IType, body: B) -> Self
             where IType: Into<Type<'a>>
         {
             IndicesPutMappingRequest {
                 url: IndicesPutMappingUrlParams::Type(ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesPutMappingRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesPutMappingRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2910,37 +2910,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesValidateQueryRequest<'a, R> {
+    pub struct IndicesValidateQueryRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesValidateQueryRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesValidateQueryRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesValidateQueryRequest {
                 url: IndicesValidateQueryUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesValidateQueryRequest {
                 url: IndicesValidateQueryUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             IndicesValidateQueryRequest {
                 url: IndicesValidateQueryUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesValidateQueryRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesValidateQueryRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2996,28 +2996,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ClearScrollRequest<'a, R> {
+    pub struct ClearScrollRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> ClearScrollRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> ClearScrollRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             ClearScrollRequest {
                 url: ClearScrollUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_scroll_id<IScrollId>(scroll_id: IScrollId, body: R) -> Self
+        pub fn for_scroll_id<IScrollId>(scroll_id: IScrollId, body: B) -> Self
             where IScrollId: Into<ScrollId<'a>>
         {
             ClearScrollRequest {
                 url: ClearScrollUrlParams::ScrollId(scroll_id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for ClearScrollRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for ClearScrollRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -3122,20 +3122,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesUpdateAliasesRequest<'a, R> {
+    pub struct IndicesUpdateAliasesRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesUpdateAliasesRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesUpdateAliasesRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesUpdateAliasesRequest {
                 url: IndicesUpdateAliasesUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesUpdateAliasesRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesUpdateAliasesRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3214,37 +3214,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MpercolateRequest<'a, R> {
+    pub struct MpercolateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> MpercolateRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> MpercolateRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             MpercolateRequest {
                 url: MpercolateUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             MpercolateRequest {
                 url: MpercolateUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             MpercolateRequest {
                 url: MpercolateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for MpercolateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for MpercolateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3270,22 +3270,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesOpenRequest<'a, R> {
+    pub struct IndicesOpenRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesOpenRequest<'a, R> {
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+    impl<'a, B> IndicesOpenRequest<'a, B> {
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesOpenRequest {
                 url: IndicesOpenUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesOpenRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesOpenRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3363,31 +3363,31 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct UpdateByQueryRequest<'a, R> {
+    pub struct UpdateByQueryRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> UpdateByQueryRequest<'a, R> {
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+    impl<'a, B> UpdateByQueryRequest<'a, B> {
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             UpdateByQueryRequest {
                 url: UpdateByQueryUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             UpdateByQueryRequest {
                 url: UpdateByQueryUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for UpdateByQueryRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for UpdateByQueryRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3425,37 +3425,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MtermvectorsRequest<'a, R> {
+    pub struct MtermvectorsRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> MtermvectorsRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> MtermvectorsRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             MtermvectorsRequest {
                 url: MtermvectorsUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             MtermvectorsRequest {
                 url: MtermvectorsUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             MtermvectorsRequest {
                 url: MtermvectorsUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for MtermvectorsRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for MtermvectorsRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3525,14 +3525,14 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SnapshotRestoreRequest<'a, R> {
+    pub struct SnapshotRestoreRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> SnapshotRestoreRequest<'a, R> {
+    impl<'a, B> SnapshotRestoreRequest<'a, B> {
         pub fn for_repository_snapshot<IRepository, ISnapshot>(repository: IRepository,
                                                                snapshot: ISnapshot,
-                                                               body: R)
+                                                               body: B)
                                                                -> Self
             where IRepository: Into<Repository<'a>>,
                   ISnapshot: Into<Snapshot<'a>>
@@ -3541,12 +3541,12 @@ pub mod endpoints {
                 url: SnapshotRestoreUrlParams::RepositorySnapshot(repository.into(),
                                                                   snapshot.into())
                     .url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for SnapshotRestoreRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for SnapshotRestoreRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3566,20 +3566,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ReindexRequest<'a, R> {
+    pub struct ReindexRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> ReindexRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> ReindexRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             ReindexRequest {
                 url: ReindexUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for ReindexRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for ReindexRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3899,20 +3899,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ClusterRerouteRequest<'a, R> {
+    pub struct ClusterRerouteRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> ClusterRerouteRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> ClusterRerouteRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             ClusterRerouteRequest {
                 url: ClusterRerouteUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for ClusterRerouteRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for ClusterRerouteRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4133,22 +4133,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct PutTemplateRequest<'a, R> {
+    pub struct PutTemplateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> PutTemplateRequest<'a, R> {
-        pub fn for_id<IId>(id: IId, body: R) -> Self
+    impl<'a, B> PutTemplateRequest<'a, B> {
+        pub fn for_id<IId>(id: IId, body: B) -> Self
             where IId: Into<Id<'a>>
         {
             PutTemplateRequest {
                 url: PutTemplateUrlParams::Id(id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for PutTemplateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for PutTemplateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4222,14 +4222,14 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SnapshotCreateRequest<'a, R> {
+    pub struct SnapshotCreateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> SnapshotCreateRequest<'a, R> {
+    impl<'a, B> SnapshotCreateRequest<'a, B> {
         pub fn for_repository_snapshot<IRepository, ISnapshot>(repository: IRepository,
                                                                snapshot: ISnapshot,
-                                                               body: R)
+                                                               body: B)
                                                                -> Self
             where IRepository: Into<Repository<'a>>,
                   ISnapshot: Into<Snapshot<'a>>
@@ -4238,12 +4238,12 @@ pub mod endpoints {
                 url: SnapshotCreateUrlParams::RepositorySnapshot(repository.into(),
                                                                  snapshot.into())
                     .url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for SnapshotCreateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for SnapshotCreateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4270,28 +4270,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ScrollRequest<'a, R> {
+    pub struct ScrollRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> ScrollRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> ScrollRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             ScrollRequest {
                 url: ScrollUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_scroll_id<IScrollId>(scroll_id: IScrollId, body: R) -> Self
+        pub fn for_scroll_id<IScrollId>(scroll_id: IScrollId, body: B) -> Self
             where IScrollId: Into<ScrollId<'a>>
         {
             ScrollRequest {
                 url: ScrollUrlParams::ScrollId(scroll_id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for ScrollRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for ScrollRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4396,37 +4396,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MgetRequest<'a, R> {
+    pub struct MgetRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> MgetRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> MgetRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             MgetRequest {
                 url: MgetUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             MgetRequest {
                 url: MgetUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             MgetRequest {
                 url: MgetUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for MgetRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for MgetRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4533,23 +4533,23 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct PutScriptRequest<'a, R> {
+    pub struct PutScriptRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> PutScriptRequest<'a, R> {
-        pub fn for_lang_id<ILang, IId>(lang: ILang, id: IId, body: R) -> Self
+    impl<'a, B> PutScriptRequest<'a, B> {
+        pub fn for_lang_id<ILang, IId>(lang: ILang, id: IId, body: B) -> Self
             where ILang: Into<Lang<'a>>,
                   IId: Into<Id<'a>>
         {
             PutScriptRequest {
                 url: PutScriptUrlParams::LangId(lang.into(), id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for PutScriptRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for PutScriptRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4661,24 +4661,24 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndexRequest<'a, R> {
+    pub struct IndexRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndexRequest<'a, R> {
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+    impl<'a, B> IndexRequest<'a, B> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             IndexRequest {
                 url: IndexUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
         pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
                                                    ty: IType,
                                                    id: IId,
-                                                   body: R)
+                                                   body: B)
                                                    -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
@@ -4686,12 +4686,12 @@ pub mod endpoints {
         {
             IndexRequest {
                 url: IndexUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndexRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndexRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4719,28 +4719,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesPutSettingsRequest<'a, R> {
+    pub struct IndicesPutSettingsRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesPutSettingsRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesPutSettingsRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesPutSettingsRequest {
                 url: IndicesPutSettingsUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesPutSettingsRequest {
                 url: IndicesPutSettingsUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesPutSettingsRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesPutSettingsRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Put,
@@ -4842,20 +4842,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ClusterPutSettingsRequest<'a, R> {
+    pub struct ClusterPutSettingsRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> ClusterPutSettingsRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> ClusterPutSettingsRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             ClusterPutSettingsRequest {
                 url: ClusterPutSettingsUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for ClusterPutSettingsRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for ClusterPutSettingsRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Put,
@@ -4886,15 +4886,15 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct UpdateRequest<'a, R> {
+    pub struct UpdateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> UpdateRequest<'a, R> {
+    impl<'a, B> UpdateRequest<'a, B> {
         pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
                                                    ty: IType,
                                                    id: IId,
-                                                   body: R)
+                                                   body: B)
                                                    -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
@@ -4902,12 +4902,12 @@ pub mod endpoints {
         {
             UpdateRequest {
                 url: UpdateUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for UpdateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for UpdateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4934,23 +4934,23 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesPutAliasRequest<'a, R> {
+    pub struct IndicesPutAliasRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesPutAliasRequest<'a, R> {
-        pub fn for_index_name<IIndex, IName>(index: IIndex, name: IName, body: R) -> Self
+    impl<'a, B> IndicesPutAliasRequest<'a, B> {
+        pub fn for_index_name<IIndex, IName>(index: IIndex, name: IName, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IName: Into<Name<'a>>
         {
             IndicesPutAliasRequest {
                 url: IndicesPutAliasUrlParams::IndexName(index.into(), name.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesPutAliasRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesPutAliasRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5020,24 +5020,24 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct CountPercolateRequest<'a, R> {
+    pub struct CountPercolateRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> CountPercolateRequest<'a, R> {
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
+    impl<'a, B> CountPercolateRequest<'a, B> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             CountPercolateRequest {
                 url: CountPercolateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
         pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
                                                    ty: IType,
                                                    id: IId,
-                                                   body: R)
+                                                   body: B)
                                                    -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
@@ -5045,12 +5045,12 @@ pub mod endpoints {
         {
             CountPercolateRequest {
                 url: CountPercolateUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for CountPercolateRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for CountPercolateRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5078,28 +5078,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesUpgradeRequest<'a, R> {
+    pub struct IndicesUpgradeRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesUpgradeRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesUpgradeRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesUpgradeRequest {
                 url: IndicesUpgradeUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesUpgradeRequest {
                 url: IndicesUpgradeUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesUpgradeRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesUpgradeRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5204,34 +5204,34 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesRolloverRequest<'a, R> {
+    pub struct IndicesRolloverRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesRolloverRequest<'a, R> {
-        pub fn for_alias<IAlias>(alias: IAlias, body: R) -> Self
+    impl<'a, B> IndicesRolloverRequest<'a, B> {
+        pub fn for_alias<IAlias>(alias: IAlias, body: B) -> Self
             where IAlias: Into<Alias<'a>>
         {
             IndicesRolloverRequest {
                 url: IndicesRolloverUrlParams::Alias(alias.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
         pub fn for_alias_new_index<IAlias, INewIndex>(alias: IAlias,
                                                       new_index: INewIndex,
-                                                      body: R)
+                                                      body: B)
                                                       -> Self
             where IAlias: Into<Alias<'a>>,
                   INewIndex: Into<NewIndex<'a>>
         {
             IndicesRolloverRequest {
                 url: IndicesRolloverUrlParams::AliasNewIndex(alias.into(), new_index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesRolloverRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesRolloverRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5257,22 +5257,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ReindexRethrottleRequest<'a, R> {
+    pub struct ReindexRethrottleRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> ReindexRethrottleRequest<'a, R> {
-        pub fn for_task_id<ITaskId>(task_id: ITaskId, body: R) -> Self
+    impl<'a, B> ReindexRethrottleRequest<'a, B> {
+        pub fn for_task_id<ITaskId>(task_id: ITaskId, body: B) -> Self
             where ITaskId: Into<TaskId<'a>>
         {
             ReindexRethrottleRequest {
                 url: ReindexRethrottleUrlParams::TaskId(task_id.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for ReindexRethrottleRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for ReindexRethrottleRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5297,22 +5297,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SnapshotCreateRepositoryRequest<'a, R> {
+    pub struct SnapshotCreateRepositoryRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> SnapshotCreateRepositoryRequest<'a, R> {
-        pub fn for_repository<IRepository>(repository: IRepository, body: R) -> Self
+    impl<'a, B> SnapshotCreateRepositoryRequest<'a, B> {
+        pub fn for_repository<IRepository>(repository: IRepository, body: B) -> Self
             where IRepository: Into<Repository<'a>>
         {
             SnapshotCreateRepositoryRequest {
                 url: SnapshotCreateRepositoryUrlParams::Repository(repository.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for SnapshotCreateRepositoryRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for SnapshotCreateRepositoryRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5393,28 +5393,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesAnalyzeRequest<'a, R> {
+    pub struct IndicesAnalyzeRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesAnalyzeRequest<'a, R> {
-        pub fn new(body: R) -> Self {
+    impl<'a, B> IndicesAnalyzeRequest<'a, B> {
+        pub fn new(body: B) -> Self {
             IndicesAnalyzeRequest {
                 url: IndicesAnalyzeUrlParams::None.url(),
-                body: Body::new(body),
+                body: body,
             }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesAnalyzeRequest {
                 url: IndicesAnalyzeUrlParams::Index(index.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesAnalyzeRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesAnalyzeRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5524,23 +5524,23 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesShrinkRequest<'a, R> {
+    pub struct IndicesShrinkRequest<'a, B> {
         pub url: Url<'a>,
-        pub body: Body<R>,
+        pub body: B,
     }
-    impl<'a, R> IndicesShrinkRequest<'a, R> {
-        pub fn for_index_target<IIndex, ITarget>(index: IIndex, target: ITarget, body: R) -> Self
+    impl<'a, B> IndicesShrinkRequest<'a, B> {
+        pub fn for_index_target<IIndex, ITarget>(index: IIndex, target: ITarget, body: B) -> Self
             where IIndex: Into<Index<'a>>,
                   ITarget: Into<Target<'a>>
         {
             IndicesShrinkRequest {
                 url: IndicesShrinkUrlParams::IndexTarget(index.into(), target.into()).url(),
-                body: Body::new(body),
+                body: body,
             }
         }
     }
-    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesShrinkRequest<'a, R> {
-        fn into(self) -> HttpRequest<'a, R> {
+    impl<'a, B> Into<HttpRequest<'a, B>> for IndicesShrinkRequest<'a, B> {
+        fn into(self) -> HttpRequest<'a, B> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5813,6 +5813,7 @@ pub mod http {
     use std::ops::Deref;
 
     # [ derive ( Debug , PartialEq , Clone ) ]
+    # [ doc = r" A wrapper around an owned or borrowed url." ]
     pub struct Url<'a>(Cow<'a, str>);
     impl<'a> From<&'a str> for Url<'a> {
         fn from(value: &'a str) -> Url<'a> {
@@ -5830,36 +5831,22 @@ pub mod http {
             &self.0
         }
     }
-    # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct Body<R>(R);
+    # [ doc = r" A default body type." ]
     pub type DefaultBody = &'static [u8];
-    impl<R> Body<R> {
-        pub fn new(inner: R) -> Self {
-            Body(inner)
-        }
-        pub fn into_inner(self) -> R {
-            self.0
-        }
-    }
-    impl Body<DefaultBody> {
-        pub fn none() -> Self {
-            Body(&[])
-        }
-    }
-    impl<R> AsRef<[u8]> for Body<R>
-        where R: AsRef<[u8]>
-    {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
-        }
+    # [ doc = r" A convenience method for a default, empty body." ]
+    # [ doc = r" This method doesn't allocate." ]
+    pub fn empty_body() -> DefaultBody {
+        &[]
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct HttpRequest<'a, R> {
+    # [ doc = r" A general request type that all endpoints can be converted into." ]
+    pub struct HttpRequest<'a, B> {
         pub url: Url<'a>,
         pub method: HttpMethod,
-        pub body: Option<Body<R>>,
+        pub body: Option<B>,
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
+    # [ doc = r" A standard HTTP verb." ]
     pub enum HttpMethod {
         Head,
         Get,

--- a/src/genned.rs
+++ b/src/genned.rs
@@ -22,36 +22,26 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesCloseRequest<'a> {
+    pub struct IndicesCloseRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesCloseRequest<'a> {
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesCloseRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> IndicesCloseRequest<'a, R> {
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesCloseRequest {
                 url: IndicesCloseUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesCloseRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesCloseRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesCloseRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -78,24 +68,15 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> DeleteScriptRequest<'a> {
-        pub fn for_lang_id<ILang, IId>(lang: ILang, id: IId) -> DeleteScriptRequest<'a>
+        pub fn for_lang_id<ILang, IId>(lang: ILang, id: IId) -> Self
             where ILang: Into<Lang<'a>>,
                   IId: Into<Id<'a>>
         {
             DeleteScriptRequest { url: DeleteScriptUrlParams::LangId(lang.into(), id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a DeleteScriptRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for DeleteScriptRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for DeleteScriptRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -136,51 +117,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct TermvectorsRequest<'a> {
+    pub struct TermvectorsRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> TermvectorsRequest<'a> {
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> TermvectorsRequest<'a>
+    impl<'a, R> TermvectorsRequest<'a, R> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             TermvectorsRequest {
                 url: TermvectorsUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty_id<IIndex, IType, IId, IBody>(index: IIndex,
-                                                          ty: IType,
-                                                          id: IId,
-                                                          body: IBody)
-                                                          -> TermvectorsRequest<'a>
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
+                                                   ty: IType,
+                                                   id: IId,
+                                                   body: R)
+                                                   -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
-                  IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+                  IId: Into<Id<'a>>
         {
             TermvectorsRequest {
                 url: TermvectorsUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a TermvectorsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for TermvectorsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for TermvectorsRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -208,40 +175,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct FieldStatsRequest<'a> {
+    pub struct FieldStatsRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> FieldStatsRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> FieldStatsRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> FieldStatsRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             FieldStatsRequest {
                 url: FieldStatsUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> FieldStatsRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             FieldStatsRequest {
                 url: FieldStatsUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a FieldStatsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for FieldStatsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for FieldStatsRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -272,25 +227,16 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatThreadPoolRequest<'a> {
-        pub fn new() -> CatThreadPoolRequest<'a> {
+        pub fn new() -> Self {
             CatThreadPoolRequest { url: CatThreadPoolUrlParams::None.url() }
-        } pub fn for_thread_pool_patterns < IThreadPoolPatterns > ( thread_pool_patterns : IThreadPoolPatterns ) -> CatThreadPoolRequest < 'a > where IThreadPoolPatterns : Into < ThreadPoolPatterns < 'a > > {
+        } pub fn for_thread_pool_patterns < IThreadPoolPatterns > ( thread_pool_patterns : IThreadPoolPatterns ) -> Self where IThreadPoolPatterns : Into < ThreadPoolPatterns < 'a > > {
             CatThreadPoolRequest {
                 url: CatThreadPoolUrlParams::ThreadPoolPatterns(thread_pool_patterns.into()).url(),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatThreadPoolRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatThreadPoolRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatThreadPoolRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -324,7 +270,7 @@ pub mod endpoints {
     impl<'a> SnapshotDeleteRequest<'a> {
         pub fn for_repository_snapshot<IRepository, ISnapshot>(repository: IRepository,
                                                                snapshot: ISnapshot)
-                                                               -> SnapshotDeleteRequest<'a>
+                                                               -> Self
             where IRepository: Into<Repository<'a>>,
                   ISnapshot: Into<Snapshot<'a>>
         {
@@ -335,17 +281,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotDeleteRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotDeleteRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for SnapshotDeleteRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -393,19 +330,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesGetSettingsRequest<'a> {
-        pub fn new() -> IndicesGetSettingsRequest<'a> {
+        pub fn new() -> Self {
             IndicesGetSettingsRequest { url: IndicesGetSettingsUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesGetSettingsRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesGetSettingsRequest {
                 url: IndicesGetSettingsUrlParams::Index(index.into()).url(),
             }
         }
-        pub fn for_index_name<IIndex, IName>(index: IIndex,
-                                             name: IName)
-                                             -> IndicesGetSettingsRequest<'a>
+        pub fn for_index_name<IIndex, IName>(index: IIndex, name: IName) -> Self
             where IIndex: Into<Index<'a>>,
                   IName: Into<Name<'a>>
         {
@@ -413,23 +348,14 @@ pub mod endpoints {
                 url: IndicesGetSettingsUrlParams::IndexName(index.into(), name.into()).url(),
             }
         }
-        pub fn for_name<IName>(name: IName) -> IndicesGetSettingsRequest<'a>
+        pub fn for_name<IName>(name: IName) -> Self
             where IName: Into<Name<'a>>
         {
             IndicesGetSettingsRequest { url: IndicesGetSettingsUrlParams::Name(name.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesGetSettingsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesGetSettingsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesGetSettingsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -460,38 +386,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct CreateRequest<'a> {
+    pub struct CreateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> CreateRequest<'a> {
-        pub fn for_index_ty_id<IIndex, IType, IId, IBody>(index: IIndex,
-                                                          ty: IType,
-                                                          id: IId,
-                                                          body: IBody)
-                                                          -> CreateRequest<'a>
+    impl<'a, R> CreateRequest<'a, R> {
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
+                                                   ty: IType,
+                                                   id: IId,
+                                                   body: R)
+                                                   -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
-                  IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+                  IId: Into<Id<'a>>
         {
             CreateRequest {
                 url: CreateUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CreateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CreateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for CreateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -520,8 +436,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> SnapshotDeleteRepositoryRequest<'a> {
-        pub fn for_repository<IRepository>(repository: IRepository)
-                                           -> SnapshotDeleteRepositoryRequest<'a>
+        pub fn for_repository<IRepository>(repository: IRepository) -> Self
             where IRepository: Into<Repository<'a>>
         {
             SnapshotDeleteRepositoryRequest {
@@ -529,17 +444,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotDeleteRepositoryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotDeleteRepositoryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for SnapshotDeleteRepositoryRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -559,31 +465,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ClusterAllocationExplainRequest<'a> {
+    pub struct ClusterAllocationExplainRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> ClusterAllocationExplainRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> ClusterAllocationExplainRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> ClusterAllocationExplainRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             ClusterAllocationExplainRequest {
                 url: ClusterAllocationExplainUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClusterAllocationExplainRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClusterAllocationExplainRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for ClusterAllocationExplainRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -608,32 +503,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesPutTemplateRequest<'a> {
+    pub struct IndicesPutTemplateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesPutTemplateRequest<'a> {
-        pub fn for_name<IName, IBody>(name: IName, body: IBody) -> IndicesPutTemplateRequest<'a>
-            where IName: Into<Name<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> IndicesPutTemplateRequest<'a, R> {
+        pub fn for_name<IName>(name: IName, body: R) -> Self
+            where IName: Into<Name<'a>>
         {
             IndicesPutTemplateRequest {
                 url: IndicesPutTemplateUrlParams::Name(name.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesPutTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesPutTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesPutTemplateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -664,26 +549,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesGetTemplateRequest<'a> {
-        pub fn new() -> IndicesGetTemplateRequest<'a> {
+        pub fn new() -> Self {
             IndicesGetTemplateRequest { url: IndicesGetTemplateUrlParams::None.url() }
         }
-        pub fn for_name<IName>(name: IName) -> IndicesGetTemplateRequest<'a>
+        pub fn for_name<IName>(name: IName) -> Self
             where IName: Into<Name<'a>>
         {
             IndicesGetTemplateRequest { url: IndicesGetTemplateUrlParams::Name(name.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesGetTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesGetTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesGetTemplateRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -723,17 +599,15 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> ClusterStateRequest<'a> {
-        pub fn new() -> ClusterStateRequest<'a> {
+        pub fn new() -> Self {
             ClusterStateRequest { url: ClusterStateUrlParams::None.url() }
         }
-        pub fn for_metric<IMetric>(metric: IMetric) -> ClusterStateRequest<'a>
+        pub fn for_metric<IMetric>(metric: IMetric) -> Self
             where IMetric: Into<Metric<'a>>
         {
             ClusterStateRequest { url: ClusterStateUrlParams::Metric(metric.into()).url() }
         }
-        pub fn for_metric_index<IMetric, IIndex>(metric: IMetric,
-                                                 index: IIndex)
-                                                 -> ClusterStateRequest<'a>
+        pub fn for_metric_index<IMetric, IIndex>(metric: IMetric, index: IIndex) -> Self
             where IMetric: Into<Metric<'a>>,
                   IIndex: Into<Index<'a>>
         {
@@ -742,17 +616,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClusterStateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClusterStateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for ClusterStateRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -790,53 +655,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MsearchTemplateRequest<'a> {
+    pub struct MsearchTemplateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> MsearchTemplateRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> MsearchTemplateRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> MsearchTemplateRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             MsearchTemplateRequest {
                 url: MsearchTemplateUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> MsearchTemplateRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             MsearchTemplateRequest {
                 url: MsearchTemplateUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> MsearchTemplateRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             MsearchTemplateRequest {
                 url: MsearchTemplateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a MsearchTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for MsearchTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for MsearchTemplateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -874,53 +723,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct BulkRequest<'a> {
+    pub struct BulkRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> BulkRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> BulkRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> BulkRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             BulkRequest {
                 url: BulkUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> BulkRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             BulkRequest {
                 url: BulkUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> BulkRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             BulkRequest {
                 url: BulkUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a BulkRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for BulkRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for BulkRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -951,38 +784,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ExplainRequest<'a> {
+    pub struct ExplainRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> ExplainRequest<'a> {
-        pub fn for_index_ty_id<IIndex, IType, IId, IBody>(index: IIndex,
-                                                          ty: IType,
-                                                          id: IId,
-                                                          body: IBody)
-                                                          -> ExplainRequest<'a>
+    impl<'a, R> ExplainRequest<'a, R> {
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
+                                                   ty: IType,
+                                                   id: IId,
+                                                   body: R)
+                                                   -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
-                  IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+                  IId: Into<Id<'a>>
         {
             ExplainRequest {
                 url: ExplainUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ExplainRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ExplainRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for ExplainRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1010,40 +833,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SuggestRequest<'a> {
+    pub struct SuggestRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> SuggestRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> SuggestRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> SuggestRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             SuggestRequest {
                 url: SuggestUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> SuggestRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             SuggestRequest {
                 url: SuggestUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SuggestRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SuggestRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for SuggestRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1074,11 +885,10 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> SnapshotGetRepositoryRequest<'a> {
-        pub fn new() -> SnapshotGetRepositoryRequest<'a> {
+        pub fn new() -> Self {
             SnapshotGetRepositoryRequest { url: SnapshotGetRepositoryUrlParams::None.url() }
         }
-        pub fn for_repository<IRepository>(repository: IRepository)
-                                           -> SnapshotGetRepositoryRequest<'a>
+        pub fn for_repository<IRepository>(repository: IRepository) -> Self
             where IRepository: Into<Repository<'a>>
         {
             SnapshotGetRepositoryRequest {
@@ -1086,17 +896,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotGetRepositoryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotGetRepositoryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for SnapshotGetRepositoryRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -1123,40 +924,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct RenderSearchTemplateRequest<'a> {
+    pub struct RenderSearchTemplateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> RenderSearchTemplateRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> RenderSearchTemplateRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> RenderSearchTemplateRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             RenderSearchTemplateRequest {
                 url: RenderSearchTemplateUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_id<IId, IBody>(id: IId, body: IBody) -> RenderSearchTemplateRequest<'a>
-            where IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_id<IId>(id: IId, body: R) -> Self
+            where IId: Into<Id<'a>>
         {
             RenderSearchTemplateRequest {
                 url: RenderSearchTemplateUrlParams::Id(id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a RenderSearchTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for RenderSearchTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for RenderSearchTemplateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1204,17 +993,15 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesStatsRequest<'a> {
-        pub fn new() -> IndicesStatsRequest<'a> {
+        pub fn new() -> Self {
             IndicesStatsRequest { url: IndicesStatsUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesStatsRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesStatsRequest { url: IndicesStatsUrlParams::Index(index.into()).url() }
         }
-        pub fn for_index_metric<IIndex, IMetric>(index: IIndex,
-                                                 metric: IMetric)
-                                                 -> IndicesStatsRequest<'a>
+        pub fn for_index_metric<IIndex, IMetric>(index: IIndex, metric: IMetric) -> Self
             where IIndex: Into<Index<'a>>,
                   IMetric: Into<Metric<'a>>
         {
@@ -1222,23 +1009,14 @@ pub mod endpoints {
                 url: IndicesStatsUrlParams::IndexMetric(index.into(), metric.into()).url(),
             }
         }
-        pub fn for_metric<IMetric>(metric: IMetric) -> IndicesStatsRequest<'a>
+        pub fn for_metric<IMetric>(metric: IMetric) -> Self
             where IMetric: Into<Metric<'a>>
         {
             IndicesStatsRequest { url: IndicesStatsUrlParams::Metric(metric.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesStatsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesStatsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesStatsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -1262,21 +1040,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatRepositoriesRequest<'a> {
-        pub fn new() -> CatRepositoriesRequest<'a> {
+        pub fn new() -> Self {
             CatRepositoriesRequest { url: CatRepositoriesUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatRepositoriesRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatRepositoriesRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatRepositoriesRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -1304,44 +1073,32 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesForcemergeRequest<'a> {
+    pub struct IndicesForcemergeRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesForcemergeRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesForcemergeRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesForcemergeRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesForcemergeRequest {
                 url: IndicesForcemergeUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesForcemergeRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesForcemergeRequest {
                 url: IndicesForcemergeUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesForcemergeRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesForcemergeRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesForcemergeRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -1361,21 +1118,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> PingRequest<'a> {
-        pub fn new() -> PingRequest<'a> {
+        pub fn new() -> Self {
             PingRequest { url: PingUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a PingRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Head,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for PingRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for PingRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Head,
@@ -1404,23 +1152,14 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> TasksGetRequest<'a> {
-        pub fn for_task_id<ITaskId>(task_id: ITaskId) -> TasksGetRequest<'a>
+        pub fn for_task_id<ITaskId>(task_id: ITaskId) -> Self
             where ITaskId: Into<TaskId<'a>>
         {
             TasksGetRequest { url: TasksGetUrlParams::TaskId(task_id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a TasksGetRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for TasksGetRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for TasksGetRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -1449,23 +1188,14 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesExistsRequest<'a> {
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesExistsRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesExistsRequest { url: IndicesExistsUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesExistsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Head,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesExistsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesExistsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Head,
@@ -1493,44 +1223,32 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesFlushSyncedRequest<'a> {
+    pub struct IndicesFlushSyncedRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesFlushSyncedRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesFlushSyncedRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesFlushSyncedRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesFlushSyncedRequest {
                 url: IndicesFlushSyncedUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesFlushSyncedRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesFlushSyncedRequest {
                 url: IndicesFlushSyncedUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesFlushSyncedRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesFlushSyncedRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesFlushSyncedRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -1564,53 +1282,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MsearchRequest<'a> {
+    pub struct MsearchRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> MsearchRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> MsearchRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> MsearchRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             MsearchRequest {
                 url: MsearchUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> MsearchRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             MsearchRequest {
                 url: MsearchUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> MsearchRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             MsearchRequest {
                 url: MsearchUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a MsearchRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for MsearchRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for MsearchRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1634,21 +1336,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> InfoRequest<'a> {
-        pub fn new() -> InfoRequest<'a> {
+        pub fn new() -> Self {
             InfoRequest { url: InfoUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a InfoRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for InfoRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for InfoRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -1686,53 +1379,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SearchTemplateRequest<'a> {
+    pub struct SearchTemplateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> SearchTemplateRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> SearchTemplateRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> SearchTemplateRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             SearchTemplateRequest {
                 url: SearchTemplateUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> SearchTemplateRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             SearchTemplateRequest {
                 url: SearchTemplateUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> SearchTemplateRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             SearchTemplateRequest {
                 url: SearchTemplateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SearchTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SearchTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for SearchTemplateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1761,23 +1438,14 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesDeleteRequest<'a> {
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesDeleteRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesDeleteRequest { url: IndicesDeleteUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesDeleteRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesDeleteRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesDeleteRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -1813,45 +1481,31 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct DeleteByQueryRequest<'a> {
+    pub struct DeleteByQueryRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> DeleteByQueryRequest<'a> {
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> DeleteByQueryRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> DeleteByQueryRequest<'a, R> {
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             DeleteByQueryRequest {
                 url: DeleteByQueryUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> DeleteByQueryRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             DeleteByQueryRequest {
                 url: DeleteByQueryUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a DeleteByQueryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for DeleteByQueryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for DeleteByQueryRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -1880,23 +1534,14 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> DeleteTemplateRequest<'a> {
-        pub fn for_id<IId>(id: IId) -> DeleteTemplateRequest<'a>
+        pub fn for_id<IId>(id: IId) -> Self
             where IId: Into<Id<'a>>
         {
             DeleteTemplateRequest { url: DeleteTemplateUrlParams::Id(id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a DeleteTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for DeleteTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for DeleteTemplateRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -1921,32 +1566,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesCreateRequest<'a> {
+    pub struct IndicesCreateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesCreateRequest<'a> {
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesCreateRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> IndicesCreateRequest<'a, R> {
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesCreateRequest {
                 url: IndicesCreateUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesCreateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Put,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesCreateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesCreateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Put,
@@ -1987,51 +1622,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct PercolateRequest<'a> {
+    pub struct PercolateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> PercolateRequest<'a> {
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> PercolateRequest<'a>
+    impl<'a, R> PercolateRequest<'a, R> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             PercolateRequest {
                 url: PercolateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty_id<IIndex, IType, IId, IBody>(index: IIndex,
-                                                          ty: IType,
-                                                          id: IId,
-                                                          body: IBody)
-                                                          -> PercolateRequest<'a>
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
+                                                   ty: IType,
+                                                   id: IId,
+                                                   body: R)
+                                                   -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
-                  IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+                  IId: Into<Id<'a>>
         {
             PercolateRequest {
                 url: PercolateUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a PercolateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for PercolateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for PercolateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2069,53 +1690,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SearchRequest<'a> {
+    pub struct SearchRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> SearchRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> SearchRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> SearchRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             SearchRequest {
                 url: SearchUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> SearchRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             SearchRequest {
                 url: SearchUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> SearchRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             SearchRequest {
                 url: SearchUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SearchRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SearchRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for SearchRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2139,21 +1744,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatNodeattrsRequest<'a> {
-        pub fn new() -> CatNodeattrsRequest<'a> {
+        pub fn new() -> Self {
             CatNodeattrsRequest { url: CatNodeattrsUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatNodeattrsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatNodeattrsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatNodeattrsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -2179,38 +1775,26 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SnapshotVerifyRepositoryRequest<'a> {
+    pub struct SnapshotVerifyRepositoryRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> SnapshotVerifyRepositoryRequest<'a> {
-        pub fn for_repository<IRepository, IBody>(repository: IRepository,
-                                                  body: IBody)
-                                                  -> SnapshotVerifyRepositoryRequest<'a>
-            where IRepository: Into<Repository<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> SnapshotVerifyRepositoryRequest<'a, R> {
+        pub fn for_repository<IRepository>(repository: IRepository, body: R) -> Self
+            where IRepository: Into<Repository<'a>>
         {
             SnapshotVerifyRepositoryRequest {
                 url: SnapshotVerifyRepositoryUrlParams::Repository(repository.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotVerifyRepositoryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotVerifyRepositoryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for SnapshotVerifyRepositoryRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -2244,53 +1828,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct CountRequest<'a> {
+    pub struct CountRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> CountRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> CountRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> CountRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             CountRequest {
                 url: CountUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> CountRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             CountRequest {
                 url: CountUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> CountRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             CountRequest {
                 url: CountUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CountRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CountRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for CountRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -2321,26 +1889,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatAllocationRequest<'a> {
-        pub fn new() -> CatAllocationRequest<'a> {
+        pub fn new() -> Self {
             CatAllocationRequest { url: CatAllocationUrlParams::None.url() }
         }
-        pub fn for_node_id<INodeId>(node_id: INodeId) -> CatAllocationRequest<'a>
+        pub fn for_node_id<INodeId>(node_id: INodeId) -> Self
             where INodeId: Into<NodeId<'a>>
         {
             CatAllocationRequest { url: CatAllocationUrlParams::NodeId(node_id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatAllocationRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatAllocationRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatAllocationRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -2368,44 +1927,32 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesFlushRequest<'a> {
+    pub struct IndicesFlushRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesFlushRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesFlushRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesFlushRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesFlushRequest {
                 url: IndicesFlushUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesFlushRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesFlushRequest {
                 url: IndicesFlushUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesFlushRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesFlushRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesFlushRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -2429,44 +1976,32 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesRefreshRequest<'a> {
+    pub struct IndicesRefreshRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesRefreshRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesRefreshRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesRefreshRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesRefreshRequest {
                 url: IndicesRefreshUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesRefreshRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesRefreshRequest {
                 url: IndicesRefreshUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesRefreshRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesRefreshRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesRefreshRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -2486,21 +2021,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatHelpRequest<'a> {
-        pub fn new() -> CatHelpRequest<'a> {
+        pub fn new() -> Self {
             CatHelpRequest { url: CatHelpUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatHelpRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatHelpRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatHelpRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -2528,44 +2054,32 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SearchShardsRequest<'a> {
+    pub struct SearchShardsRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> SearchShardsRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> SearchShardsRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> SearchShardsRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             SearchShardsRequest {
                 url: SearchShardsUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> SearchShardsRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             SearchShardsRequest {
                 url: SearchShardsUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SearchShardsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SearchShardsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for SearchShardsRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -2592,26 +2106,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> ClusterHealthRequest<'a> {
-        pub fn new() -> ClusterHealthRequest<'a> {
+        pub fn new() -> Self {
             ClusterHealthRequest { url: ClusterHealthUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> ClusterHealthRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             ClusterHealthRequest { url: ClusterHealthUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClusterHealthRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClusterHealthRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for ClusterHealthRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -2657,16 +2162,14 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesExistsAliasRequest<'a> {
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesExistsAliasRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesExistsAliasRequest {
                 url: IndicesExistsAliasUrlParams::Index(index.into()).url(),
             }
         }
-        pub fn for_index_name<IIndex, IName>(index: IIndex,
-                                             name: IName)
-                                             -> IndicesExistsAliasRequest<'a>
+        pub fn for_index_name<IIndex, IName>(index: IIndex, name: IName) -> Self
             where IIndex: Into<Index<'a>>,
                   IName: Into<Name<'a>>
         {
@@ -2674,23 +2177,14 @@ pub mod endpoints {
                 url: IndicesExistsAliasUrlParams::IndexName(index.into(), name.into()).url(),
             }
         }
-        pub fn for_name<IName>(name: IName) -> IndicesExistsAliasRequest<'a>
+        pub fn for_name<IName>(name: IName) -> Self
             where IName: Into<Name<'a>>
         {
             IndicesExistsAliasRequest { url: IndicesExistsAliasUrlParams::Name(name.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesExistsAliasRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Head,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesExistsAliasRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesExistsAliasRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Head,
@@ -2749,16 +2243,14 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesGetFieldMappingRequest<'a> {
-        pub fn for_fields<IFields>(fields: IFields) -> IndicesGetFieldMappingRequest<'a>
+        pub fn for_fields<IFields>(fields: IFields) -> Self
             where IFields: Into<Fields<'a>>
         {
             IndicesGetFieldMappingRequest {
                 url: IndicesGetFieldMappingUrlParams::Fields(fields.into()).url(),
             }
         }
-        pub fn for_index_fields<IIndex, IFields>(index: IIndex,
-                                                 fields: IFields)
-                                                 -> IndicesGetFieldMappingRequest<'a>
+        pub fn for_index_fields<IIndex, IFields>(index: IIndex, fields: IFields) -> Self
             where IIndex: Into<Index<'a>>,
                   IFields: Into<Fields<'a>>
         {
@@ -2770,7 +2262,7 @@ pub mod endpoints {
         pub fn for_index_ty_fields<IIndex, IType, IFields>(index: IIndex,
                                                            ty: IType,
                                                            fields: IFields)
-                                                           -> IndicesGetFieldMappingRequest<'a>
+                                                           -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
                   IFields: Into<Fields<'a>>
@@ -2782,9 +2274,7 @@ pub mod endpoints {
                     .url(),
             }
         }
-        pub fn for_ty_fields<IType, IFields>(ty: IType,
-                                             fields: IFields)
-                                             -> IndicesGetFieldMappingRequest<'a>
+        pub fn for_ty_fields<IType, IFields>(ty: IType, fields: IFields) -> Self
             where IType: Into<Type<'a>>,
                   IFields: Into<Fields<'a>>
         {
@@ -2793,17 +2283,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesGetFieldMappingRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesGetFieldMappingRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesGetFieldMappingRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -2828,32 +2309,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IngestPutPipelineRequest<'a> {
+    pub struct IngestPutPipelineRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IngestPutPipelineRequest<'a> {
-        pub fn for_id<IId, IBody>(id: IId, body: IBody) -> IngestPutPipelineRequest<'a>
-            where IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> IngestPutPipelineRequest<'a, R> {
+        pub fn for_id<IId>(id: IId, body: R) -> Self
+            where IId: Into<Id<'a>>
         {
             IngestPutPipelineRequest {
                 url: IngestPutPipelineUrlParams::Id(id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IngestPutPipelineRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Put,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IngestPutPipelineRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IngestPutPipelineRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Put,
@@ -2877,21 +2348,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> ClusterPendingTasksRequest<'a> {
-        pub fn new() -> ClusterPendingTasksRequest<'a> {
+        pub fn new() -> Self {
             ClusterPendingTasksRequest { url: ClusterPendingTasksUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClusterPendingTasksRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClusterPendingTasksRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for ClusterPendingTasksRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -2919,40 +2381,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IngestSimulateRequest<'a> {
+    pub struct IngestSimulateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IngestSimulateRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IngestSimulateRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IngestSimulateRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IngestSimulateRequest {
                 url: IngestSimulateUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_id<IId, IBody>(id: IId, body: IBody) -> IngestSimulateRequest<'a>
-            where IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_id<IId>(id: IId, body: R) -> Self
+            where IId: Into<Id<'a>>
         {
             IngestSimulateRequest {
                 url: IngestSimulateUrlParams::Id(id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IngestSimulateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IngestSimulateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IngestSimulateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3000,17 +2450,15 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesGetAliasRequest<'a> {
-        pub fn new() -> IndicesGetAliasRequest<'a> {
+        pub fn new() -> Self {
             IndicesGetAliasRequest { url: IndicesGetAliasUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesGetAliasRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesGetAliasRequest { url: IndicesGetAliasUrlParams::Index(index.into()).url() }
         }
-        pub fn for_index_name<IIndex, IName>(index: IIndex,
-                                             name: IName)
-                                             -> IndicesGetAliasRequest<'a>
+        pub fn for_index_name<IIndex, IName>(index: IIndex, name: IName) -> Self
             where IIndex: Into<Index<'a>>,
                   IName: Into<Name<'a>>
         {
@@ -3018,23 +2466,14 @@ pub mod endpoints {
                 url: IndicesGetAliasUrlParams::IndexName(index.into(), name.into()).url(),
             }
         }
-        pub fn for_name<IName>(name: IName) -> IndicesGetAliasRequest<'a>
+        pub fn for_name<IName>(name: IName) -> Self
             where IName: Into<Name<'a>>
         {
             IndicesGetAliasRequest { url: IndicesGetAliasUrlParams::Name(name.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesGetAliasRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesGetAliasRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesGetAliasRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3065,24 +2504,15 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> GetScriptRequest<'a> {
-        pub fn for_lang_id<ILang, IId>(lang: ILang, id: IId) -> GetScriptRequest<'a>
+        pub fn for_lang_id<ILang, IId>(lang: ILang, id: IId) -> Self
             where ILang: Into<Lang<'a>>,
                   IId: Into<Id<'a>>
         {
             GetScriptRequest { url: GetScriptUrlParams::LangId(lang.into(), id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a GetScriptRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for GetScriptRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for GetScriptRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3114,26 +2544,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesRecoveryRequest<'a> {
-        pub fn new() -> IndicesRecoveryRequest<'a> {
+        pub fn new() -> Self {
             IndicesRecoveryRequest { url: IndicesRecoveryUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesRecoveryRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesRecoveryRequest { url: IndicesRecoveryUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesRecoveryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesRecoveryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesRecoveryRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3162,23 +2583,14 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IngestDeletePipelineRequest<'a> {
-        pub fn for_id<IId>(id: IId) -> IngestDeletePipelineRequest<'a>
+        pub fn for_id<IId>(id: IId) -> Self
             where IId: Into<Id<'a>>
         {
             IngestDeletePipelineRequest { url: IngestDeletePipelineUrlParams::Id(id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IngestDeletePipelineRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IngestDeletePipelineRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IngestDeletePipelineRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -3206,44 +2618,32 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct TasksCancelRequest<'a> {
+    pub struct TasksCancelRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> TasksCancelRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> TasksCancelRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> TasksCancelRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             TasksCancelRequest {
                 url: TasksCancelUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_task_id<ITaskId, IBody>(task_id: ITaskId, body: IBody) -> TasksCancelRequest<'a>
-            where ITaskId: Into<TaskId<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_task_id<ITaskId>(task_id: ITaskId, body: R) -> Self
+            where ITaskId: Into<TaskId<'a>>
         {
             TasksCancelRequest {
                 url: TasksCancelUrlParams::TaskId(task_id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a TasksCancelRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for TasksCancelRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for TasksCancelRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -3267,44 +2667,32 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesClearCacheRequest<'a> {
+    pub struct IndicesClearCacheRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesClearCacheRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesClearCacheRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesClearCacheRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesClearCacheRequest {
                 url: IndicesClearCacheUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesClearCacheRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesClearCacheRequest {
                 url: IndicesClearCacheUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesClearCacheRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesClearCacheRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesClearCacheRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -3333,10 +2721,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> DeleteRequest<'a> {
-        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
-                                                   ty: IType,
-                                                   id: IId)
-                                                   -> DeleteRequest<'a>
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex, ty: IType, id: IId) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
                   IId: Into<Id<'a>>
@@ -3346,17 +2731,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a DeleteRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for DeleteRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for DeleteRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -3390,45 +2766,31 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesPutMappingRequest<'a> {
+    pub struct IndicesPutMappingRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesPutMappingRequest<'a> {
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> IndicesPutMappingRequest<'a>
+    impl<'a, R> IndicesPutMappingRequest<'a, R> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             IndicesPutMappingRequest {
                 url: IndicesPutMappingUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_ty<IType, IBody>(ty: IType, body: IBody) -> IndicesPutMappingRequest<'a>
-            where IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_ty<IType>(ty: IType, body: R) -> Self
+            where IType: Into<Type<'a>>
         {
             IndicesPutMappingRequest {
                 url: IndicesPutMappingUrlParams::Type(ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesPutMappingRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesPutMappingRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesPutMappingRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3459,26 +2821,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatAliasesRequest<'a> {
-        pub fn new() -> CatAliasesRequest<'a> {
+        pub fn new() -> Self {
             CatAliasesRequest { url: CatAliasesUrlParams::None.url() }
         }
-        pub fn for_name<IName>(name: IName) -> CatAliasesRequest<'a>
+        pub fn for_name<IName>(name: IName) -> Self
             where IName: Into<Name<'a>>
         {
             CatAliasesRequest { url: CatAliasesUrlParams::Name(name.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatAliasesRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatAliasesRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatAliasesRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3509,26 +2862,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> ClusterStatsRequest<'a> {
-        pub fn new() -> ClusterStatsRequest<'a> {
+        pub fn new() -> Self {
             ClusterStatsRequest { url: ClusterStatsUrlParams::None.url() }
         }
-        pub fn for_node_id<INodeId>(node_id: INodeId) -> ClusterStatsRequest<'a>
+        pub fn for_node_id<INodeId>(node_id: INodeId) -> Self
             where INodeId: Into<NodeId<'a>>
         {
             ClusterStatsRequest { url: ClusterStatsUrlParams::NodeId(node_id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClusterStatsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClusterStatsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for ClusterStatsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3566,55 +2910,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesValidateQueryRequest<'a> {
+    pub struct IndicesValidateQueryRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesValidateQueryRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesValidateQueryRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesValidateQueryRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesValidateQueryRequest {
                 url: IndicesValidateQueryUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex,
-                                        body: IBody)
-                                        -> IndicesValidateQueryRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesValidateQueryRequest {
                 url: IndicesValidateQueryUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> IndicesValidateQueryRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             IndicesValidateQueryRequest {
                 url: IndicesValidateQueryUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesValidateQueryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesValidateQueryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesValidateQueryRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3638,21 +2964,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatPendingTasksRequest<'a> {
-        pub fn new() -> CatPendingTasksRequest<'a> {
+        pub fn new() -> Self {
             CatPendingTasksRequest { url: CatPendingTasksUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatPendingTasksRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatPendingTasksRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatPendingTasksRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3679,42 +2996,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ClearScrollRequest<'a> {
+    pub struct ClearScrollRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> ClearScrollRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> ClearScrollRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> ClearScrollRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             ClearScrollRequest {
                 url: ClearScrollUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_scroll_id<IScrollId, IBody>(scroll_id: IScrollId,
-                                               body: IBody)
-                                               -> ClearScrollRequest<'a>
-            where IScrollId: Into<ScrollId<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_scroll_id<IScrollId>(scroll_id: IScrollId, body: R) -> Self
+            where IScrollId: Into<ScrollId<'a>>
         {
             ClearScrollRequest {
                 url: ClearScrollUrlParams::ScrollId(scroll_id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClearScrollRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClearScrollRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for ClearScrollRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -3745,26 +3048,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatShardsRequest<'a> {
-        pub fn new() -> CatShardsRequest<'a> {
+        pub fn new() -> Self {
             CatShardsRequest { url: CatShardsUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> CatShardsRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             CatShardsRequest { url: CatShardsUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatShardsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatShardsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatShardsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3796,10 +3090,10 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesShardStoresRequest<'a> {
-        pub fn new() -> IndicesShardStoresRequest<'a> {
+        pub fn new() -> Self {
             IndicesShardStoresRequest { url: IndicesShardStoresUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesShardStoresRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesShardStoresRequest {
@@ -3807,17 +3101,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesShardStoresRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesShardStoresRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesShardStoresRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3837,31 +3122,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesUpdateAliasesRequest<'a> {
+    pub struct IndicesUpdateAliasesRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesUpdateAliasesRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesUpdateAliasesRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesUpdateAliasesRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesUpdateAliasesRequest {
                 url: IndicesUpdateAliasesUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesUpdateAliasesRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesUpdateAliasesRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesUpdateAliasesRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -3892,26 +3166,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatSegmentsRequest<'a> {
-        pub fn new() -> CatSegmentsRequest<'a> {
+        pub fn new() -> Self {
             CatSegmentsRequest { url: CatSegmentsUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> CatSegmentsRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             CatSegmentsRequest { url: CatSegmentsUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatSegmentsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatSegmentsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatSegmentsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -3949,53 +3214,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MpercolateRequest<'a> {
+    pub struct MpercolateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> MpercolateRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> MpercolateRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> MpercolateRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             MpercolateRequest {
                 url: MpercolateUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> MpercolateRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             MpercolateRequest {
                 url: MpercolateUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> MpercolateRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             MpercolateRequest {
                 url: MpercolateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a MpercolateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for MpercolateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for MpercolateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4021,36 +3270,26 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesOpenRequest<'a> {
+    pub struct IndicesOpenRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesOpenRequest<'a> {
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesOpenRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> IndicesOpenRequest<'a, R> {
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesOpenRequest {
                 url: IndicesOpenUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesOpenRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesOpenRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesOpenRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -4079,10 +3318,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> GetRequest<'a> {
-        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
-                                                   ty: IType,
-                                                   id: IId)
-                                                   -> GetRequest<'a>
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex, ty: IType, id: IId) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
                   IId: Into<Id<'a>>
@@ -4090,17 +3326,8 @@ pub mod endpoints {
             GetRequest { url: GetUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a GetRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for GetRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for GetRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4136,45 +3363,31 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct UpdateByQueryRequest<'a> {
+    pub struct UpdateByQueryRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> UpdateByQueryRequest<'a> {
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> UpdateByQueryRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> UpdateByQueryRequest<'a, R> {
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             UpdateByQueryRequest {
                 url: UpdateByQueryUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> UpdateByQueryRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             UpdateByQueryRequest {
                 url: UpdateByQueryUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a UpdateByQueryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for UpdateByQueryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for UpdateByQueryRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4212,53 +3425,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MtermvectorsRequest<'a> {
+    pub struct MtermvectorsRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> MtermvectorsRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> MtermvectorsRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> MtermvectorsRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             MtermvectorsRequest {
                 url: MtermvectorsUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> MtermvectorsRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             MtermvectorsRequest {
                 url: MtermvectorsUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> MtermvectorsRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             MtermvectorsRequest {
                 url: MtermvectorsUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a MtermvectorsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for MtermvectorsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for MtermvectorsRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4289,26 +3486,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatRecoveryRequest<'a> {
-        pub fn new() -> CatRecoveryRequest<'a> {
+        pub fn new() -> Self {
             CatRecoveryRequest { url: CatRecoveryUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> CatRecoveryRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             CatRecoveryRequest { url: CatRecoveryUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatRecoveryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatRecoveryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatRecoveryRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4337,39 +3525,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SnapshotRestoreRequest<'a> {
+    pub struct SnapshotRestoreRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> SnapshotRestoreRequest<'a> {
-        pub fn for_repository_snapshot<IRepository, ISnapshot, IBody>
-            (repository: IRepository,
-             snapshot: ISnapshot,
-             body: IBody)
-             -> SnapshotRestoreRequest<'a>
+    impl<'a, R> SnapshotRestoreRequest<'a, R> {
+        pub fn for_repository_snapshot<IRepository, ISnapshot>(repository: IRepository,
+                                                               snapshot: ISnapshot,
+                                                               body: R)
+                                                               -> Self
             where IRepository: Into<Repository<'a>>,
-                  ISnapshot: Into<Snapshot<'a>>,
-                  IBody: Into<Body<'a>>
+                  ISnapshot: Into<Snapshot<'a>>
         {
             SnapshotRestoreRequest {
                 url: SnapshotRestoreUrlParams::RepositorySnapshot(repository.into(),
                                                                   snapshot.into())
                     .url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotRestoreRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotRestoreRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for SnapshotRestoreRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4389,31 +3566,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ReindexRequest<'a> {
+    pub struct ReindexRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> ReindexRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> ReindexRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> ReindexRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             ReindexRequest {
                 url: ReindexUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ReindexRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ReindexRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for ReindexRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4437,21 +3603,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatHealthRequest<'a> {
-        pub fn new() -> CatHealthRequest<'a> {
+        pub fn new() -> Self {
             CatHealthRequest { url: CatHealthUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatHealthRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatHealthRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatHealthRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4482,26 +3639,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatCountRequest<'a> {
-        pub fn new() -> CatCountRequest<'a> {
+        pub fn new() -> Self {
             CatCountRequest { url: CatCountUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> CatCountRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             CatCountRequest { url: CatCountUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatCountRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatCountRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatCountRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4532,26 +3680,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatSnapshotsRequest<'a> {
-        pub fn new() -> CatSnapshotsRequest<'a> {
+        pub fn new() -> Self {
             CatSnapshotsRequest { url: CatSnapshotsUrlParams::None.url() }
         }
-        pub fn for_repository<IRepository>(repository: IRepository) -> CatSnapshotsRequest<'a>
+        pub fn for_repository<IRepository>(repository: IRepository) -> Self
             where IRepository: Into<Repository<'a>>
         {
             CatSnapshotsRequest { url: CatSnapshotsUrlParams::Repository(repository.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatSnapshotsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatSnapshotsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatSnapshotsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4599,15 +3738,15 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesGetMappingRequest<'a> {
-        pub fn new() -> IndicesGetMappingRequest<'a> {
+        pub fn new() -> Self {
             IndicesGetMappingRequest { url: IndicesGetMappingUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesGetMappingRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesGetMappingRequest { url: IndicesGetMappingUrlParams::Index(index.into()).url() }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType) -> IndicesGetMappingRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
@@ -4615,23 +3754,14 @@ pub mod endpoints {
                 url: IndicesGetMappingUrlParams::IndexType(index.into(), ty.into()).url(),
             }
         }
-        pub fn for_ty<IType>(ty: IType) -> IndicesGetMappingRequest<'a>
+        pub fn for_ty<IType>(ty: IType) -> Self
             where IType: Into<Type<'a>>
         {
             IndicesGetMappingRequest { url: IndicesGetMappingUrlParams::Type(ty.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesGetMappingRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesGetMappingRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesGetMappingRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4665,7 +3795,7 @@ pub mod endpoints {
     impl<'a> SnapshotGetRequest<'a> {
         pub fn for_repository_snapshot<IRepository, ISnapshot>(repository: IRepository,
                                                                snapshot: ISnapshot)
-                                                               -> SnapshotGetRequest<'a>
+                                                               -> Self
             where IRepository: Into<Repository<'a>>,
                   ISnapshot: Into<Snapshot<'a>>
         {
@@ -4675,17 +3805,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotGetRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotGetRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for SnapshotGetRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4709,21 +3830,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatNodesRequest<'a> {
-        pub fn new() -> CatNodesRequest<'a> {
+        pub fn new() -> Self {
             CatNodesRequest { url: CatNodesUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatNodesRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatNodesRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatNodesRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4756,10 +3868,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> ExistsRequest<'a> {
-        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
-                                                   ty: IType,
-                                                   id: IId)
-                                                   -> ExistsRequest<'a>
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex, ty: IType, id: IId) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
                   IId: Into<Id<'a>>
@@ -4769,17 +3878,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ExistsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Head,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ExistsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for ExistsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Head,
@@ -4799,31 +3899,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ClusterRerouteRequest<'a> {
+    pub struct ClusterRerouteRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> ClusterRerouteRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> ClusterRerouteRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> ClusterRerouteRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             ClusterRerouteRequest {
                 url: ClusterRerouteUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClusterRerouteRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClusterRerouteRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for ClusterRerouteRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -4855,26 +3944,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> NodesHotThreadsRequest<'a> {
-        pub fn new() -> NodesHotThreadsRequest<'a> {
+        pub fn new() -> Self {
             NodesHotThreadsRequest { url: NodesHotThreadsUrlParams::None.url() }
         }
-        pub fn for_node_id<INodeId>(node_id: INodeId) -> NodesHotThreadsRequest<'a>
+        pub fn for_node_id<INodeId>(node_id: INodeId) -> Self
             where INodeId: Into<NodeId<'a>>
         {
             NodesHotThreadsRequest { url: NodesHotThreadsUrlParams::NodeId(node_id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a NodesHotThreadsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for NodesHotThreadsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for NodesHotThreadsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -4946,17 +4026,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> NodesStatsRequest<'a> {
-        pub fn new() -> NodesStatsRequest<'a> {
+        pub fn new() -> Self {
             NodesStatsRequest { url: NodesStatsUrlParams::None.url() }
         }
-        pub fn for_metric<IMetric>(metric: IMetric) -> NodesStatsRequest<'a>
+        pub fn for_metric<IMetric>(metric: IMetric) -> Self
             where IMetric: Into<Metric<'a>>
         {
             NodesStatsRequest { url: NodesStatsUrlParams::Metric(metric.into()).url() }
         }
         pub fn for_metric_index_metric<IMetric, IIndexMetric>(metric: IMetric,
                                                               index_metric: IIndexMetric)
-                                                              -> NodesStatsRequest<'a>
+                                                              -> Self
             where IMetric: Into<Metric<'a>>,
                   IIndexMetric: Into<IndexMetric<'a>>
         {
@@ -4965,30 +4045,19 @@ pub mod endpoints {
                     .url(),
             }
         }
-        pub fn for_node_id<INodeId>(node_id: INodeId) -> NodesStatsRequest<'a>
+        pub fn for_node_id<INodeId>(node_id: INodeId) -> Self
             where INodeId: Into<NodeId<'a>>
         {
             NodesStatsRequest { url: NodesStatsUrlParams::NodeId(node_id.into()).url() }
         }
-        pub fn for_node_id_metric<INodeId, IMetric>(node_id: INodeId,
-                                                    metric: IMetric)
-                                                    -> NodesStatsRequest<'a>
+        pub fn for_node_id_metric<INodeId, IMetric>(node_id: INodeId, metric: IMetric) -> Self
             where INodeId: Into<NodeId<'a>>,
                   IMetric: Into<Metric<'a>>
         {
             NodesStatsRequest {
                 url: NodesStatsUrlParams::NodeIdMetric(node_id.into(), metric.into()).url(),
             }
-        }
-        pub fn for_node_id_metric_index_metric<INodeId, IMetric, IIndexMetric>
-            (node_id: INodeId,
-             metric: IMetric,
-             index_metric: IIndexMetric)
-             -> NodesStatsRequest<'a>
-            where INodeId: Into<NodeId<'a>>,
-                  IMetric: Into<Metric<'a>>,
-                  IIndexMetric: Into<IndexMetric<'a>>
-        {
+        } pub fn for_node_id_metric_index_metric < INodeId , IMetric , IIndexMetric > ( node_id : INodeId , metric : IMetric , index_metric : IIndexMetric ) -> Self where INodeId : Into < NodeId < 'a > > , IMetric : Into < Metric < 'a > > , IIndexMetric : Into < IndexMetric < 'a > > {
             NodesStatsRequest {
                 url: NodesStatsUrlParams::NodeIdMetricIndexMetric(node_id.into(),
                                                                   metric.into(),
@@ -4997,17 +4066,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a NodesStatsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for NodesStatsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for NodesStatsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -5038,26 +4098,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IngestGetPipelineRequest<'a> {
-        pub fn new() -> IngestGetPipelineRequest<'a> {
+        pub fn new() -> Self {
             IngestGetPipelineRequest { url: IngestGetPipelineUrlParams::None.url() }
         }
-        pub fn for_id<IId>(id: IId) -> IngestGetPipelineRequest<'a>
+        pub fn for_id<IId>(id: IId) -> Self
             where IId: Into<Id<'a>>
         {
             IngestGetPipelineRequest { url: IngestGetPipelineUrlParams::Id(id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IngestGetPipelineRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IngestGetPipelineRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IngestGetPipelineRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -5082,32 +4133,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct PutTemplateRequest<'a> {
+    pub struct PutTemplateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> PutTemplateRequest<'a> {
-        pub fn for_id<IId, IBody>(id: IId, body: IBody) -> PutTemplateRequest<'a>
-            where IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> PutTemplateRequest<'a, R> {
+        pub fn for_id<IId>(id: IId, body: R) -> Self
+            where IId: Into<Id<'a>>
         {
             PutTemplateRequest {
                 url: PutTemplateUrlParams::Id(id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a PutTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for PutTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for PutTemplateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5142,10 +4183,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> GetSourceRequest<'a> {
-        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
-                                                   ty: IType,
-                                                   id: IId)
-                                                   -> GetSourceRequest<'a>
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex, ty: IType, id: IId) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
                   IId: Into<Id<'a>>
@@ -5155,17 +4193,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a GetSourceRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for GetSourceRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for GetSourceRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -5193,39 +4222,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SnapshotCreateRequest<'a> {
+    pub struct SnapshotCreateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> SnapshotCreateRequest<'a> {
-        pub fn for_repository_snapshot<IRepository, ISnapshot, IBody>
-            (repository: IRepository,
-             snapshot: ISnapshot,
-             body: IBody)
-             -> SnapshotCreateRequest<'a>
+    impl<'a, R> SnapshotCreateRequest<'a, R> {
+        pub fn for_repository_snapshot<IRepository, ISnapshot>(repository: IRepository,
+                                                               snapshot: ISnapshot,
+                                                               body: R)
+                                                               -> Self
             where IRepository: Into<Repository<'a>>,
-                  ISnapshot: Into<Snapshot<'a>>,
-                  IBody: Into<Body<'a>>
+                  ISnapshot: Into<Snapshot<'a>>
         {
             SnapshotCreateRequest {
                 url: SnapshotCreateUrlParams::RepositorySnapshot(repository.into(),
                                                                  snapshot.into())
                     .url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotCreateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotCreateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for SnapshotCreateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5252,42 +4270,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ScrollRequest<'a> {
+    pub struct ScrollRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> ScrollRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> ScrollRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> ScrollRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             ScrollRequest {
                 url: ScrollUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_scroll_id<IScrollId, IBody>(scroll_id: IScrollId,
-                                               body: IBody)
-                                               -> ScrollRequest<'a>
-            where IScrollId: Into<ScrollId<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_scroll_id<IScrollId>(scroll_id: IScrollId, body: R) -> Self
+            where IScrollId: Into<ScrollId<'a>>
         {
             ScrollRequest {
                 url: ScrollUrlParams::ScrollId(scroll_id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ScrollRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ScrollRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for ScrollRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5330,10 +4334,10 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> SnapshotStatusRequest<'a> {
-        pub fn new() -> SnapshotStatusRequest<'a> {
+        pub fn new() -> Self {
             SnapshotStatusRequest { url: SnapshotStatusUrlParams::None.url() }
         }
-        pub fn for_repository<IRepository>(repository: IRepository) -> SnapshotStatusRequest<'a>
+        pub fn for_repository<IRepository>(repository: IRepository) -> Self
             where IRepository: Into<Repository<'a>>
         {
             SnapshotStatusRequest {
@@ -5342,7 +4346,7 @@ pub mod endpoints {
         }
         pub fn for_repository_snapshot<IRepository, ISnapshot>(repository: IRepository,
                                                                snapshot: ISnapshot)
-                                                               -> SnapshotStatusRequest<'a>
+                                                               -> Self
             where IRepository: Into<Repository<'a>>,
                   ISnapshot: Into<Snapshot<'a>>
         {
@@ -5353,17 +4357,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotStatusRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotStatusRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for SnapshotStatusRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -5401,53 +4396,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct MgetRequest<'a> {
+    pub struct MgetRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> MgetRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> MgetRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> MgetRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             MgetRequest {
                 url: MgetUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> MgetRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             MgetRequest {
                 url: MgetUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> MgetRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             MgetRequest {
                 url: MgetUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a MgetRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for MgetRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for MgetRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5476,7 +4455,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesExistsTemplateRequest<'a> {
-        pub fn for_name<IName>(name: IName) -> IndicesExistsTemplateRequest<'a>
+        pub fn for_name<IName>(name: IName) -> Self
             where IName: Into<Name<'a>>
         {
             IndicesExistsTemplateRequest {
@@ -5484,17 +4463,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesExistsTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Head,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesExistsTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesExistsTemplateRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Head,
@@ -5526,26 +4496,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesGetUpgradeRequest<'a> {
-        pub fn new() -> IndicesGetUpgradeRequest<'a> {
+        pub fn new() -> Self {
             IndicesGetUpgradeRequest { url: IndicesGetUpgradeUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesGetUpgradeRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesGetUpgradeRequest { url: IndicesGetUpgradeUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesGetUpgradeRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesGetUpgradeRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesGetUpgradeRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -5572,36 +4533,23 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct PutScriptRequest<'a> {
+    pub struct PutScriptRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> PutScriptRequest<'a> {
-        pub fn for_lang_id<ILang, IId, IBody>(lang: ILang,
-                                              id: IId,
-                                              body: IBody)
-                                              -> PutScriptRequest<'a>
+    impl<'a, R> PutScriptRequest<'a, R> {
+        pub fn for_lang_id<ILang, IId>(lang: ILang, id: IId, body: R) -> Self
             where ILang: Into<Lang<'a>>,
-                  IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+                  IId: Into<Id<'a>>
         {
             PutScriptRequest {
                 url: PutScriptUrlParams::LangId(lang.into(), id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a PutScriptRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for PutScriptRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for PutScriptRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5630,23 +4578,14 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> GetTemplateRequest<'a> {
-        pub fn for_id<IId>(id: IId) -> GetTemplateRequest<'a>
+        pub fn for_id<IId>(id: IId) -> Self
             where IId: Into<Id<'a>>
         {
             GetTemplateRequest { url: GetTemplateUrlParams::Id(id.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a GetTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for GetTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for GetTemplateRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -5675,7 +4614,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesDeleteTemplateRequest<'a> {
-        pub fn for_name<IName>(name: IName) -> IndicesDeleteTemplateRequest<'a>
+        pub fn for_name<IName>(name: IName) -> Self
             where IName: Into<Name<'a>>
         {
             IndicesDeleteTemplateRequest {
@@ -5683,17 +4622,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesDeleteTemplateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesDeleteTemplateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesDeleteTemplateRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -5731,51 +4661,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndexRequest<'a> {
+    pub struct IndexRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndexRequest<'a> {
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> IndexRequest<'a>
+    impl<'a, R> IndexRequest<'a, R> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             IndexRequest {
                 url: IndexUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty_id<IIndex, IType, IId, IBody>(index: IIndex,
-                                                          ty: IType,
-                                                          id: IId,
-                                                          body: IBody)
-                                                          -> IndexRequest<'a>
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
+                                                   ty: IType,
+                                                   id: IId,
+                                                   body: R)
+                                                   -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
-                  IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+                  IId: Into<Id<'a>>
         {
             IndexRequest {
                 url: IndexUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndexRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndexRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndexRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -5803,40 +4719,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesPutSettingsRequest<'a> {
+    pub struct IndicesPutSettingsRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesPutSettingsRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesPutSettingsRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesPutSettingsRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesPutSettingsRequest {
                 url: IndicesPutSettingsUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesPutSettingsRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesPutSettingsRequest {
                 url: IndicesPutSettingsUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesPutSettingsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Put,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesPutSettingsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesPutSettingsRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Put,
@@ -5867,26 +4771,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatTemplatesRequest<'a> {
-        pub fn new() -> CatTemplatesRequest<'a> {
+        pub fn new() -> Self {
             CatTemplatesRequest { url: CatTemplatesUrlParams::None.url() }
         }
-        pub fn for_name<IName>(name: IName) -> CatTemplatesRequest<'a>
+        pub fn for_name<IName>(name: IName) -> Self
             where IName: Into<Name<'a>>
         {
             CatTemplatesRequest { url: CatTemplatesUrlParams::Name(name.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatTemplatesRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatTemplatesRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatTemplatesRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -5917,26 +4812,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatIndicesRequest<'a> {
-        pub fn new() -> CatIndicesRequest<'a> {
+        pub fn new() -> Self {
             CatIndicesRequest { url: CatIndicesUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> CatIndicesRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             CatIndicesRequest { url: CatIndicesUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatIndicesRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatIndicesRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatIndicesRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -5956,31 +4842,20 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ClusterPutSettingsRequest<'a> {
+    pub struct ClusterPutSettingsRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> ClusterPutSettingsRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> ClusterPutSettingsRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> ClusterPutSettingsRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             ClusterPutSettingsRequest {
                 url: ClusterPutSettingsUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClusterPutSettingsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Put,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClusterPutSettingsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for ClusterPutSettingsRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Put,
@@ -6011,38 +4886,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct UpdateRequest<'a> {
+    pub struct UpdateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> UpdateRequest<'a> {
-        pub fn for_index_ty_id<IIndex, IType, IId, IBody>(index: IIndex,
-                                                          ty: IType,
-                                                          id: IId,
-                                                          body: IBody)
-                                                          -> UpdateRequest<'a>
+    impl<'a, R> UpdateRequest<'a, R> {
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
+                                                   ty: IType,
+                                                   id: IId,
+                                                   body: R)
+                                                   -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
-                  IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+                  IId: Into<Id<'a>>
         {
             UpdateRequest {
                 url: UpdateUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a UpdateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for UpdateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for UpdateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -6069,36 +4934,23 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesPutAliasRequest<'a> {
+    pub struct IndicesPutAliasRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesPutAliasRequest<'a> {
-        pub fn for_index_name<IIndex, IName, IBody>(index: IIndex,
-                                                    name: IName,
-                                                    body: IBody)
-                                                    -> IndicesPutAliasRequest<'a>
+    impl<'a, R> IndicesPutAliasRequest<'a, R> {
+        pub fn for_index_name<IIndex, IName>(index: IIndex, name: IName, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IName: Into<Name<'a>>,
-                  IBody: Into<Body<'a>>
+                  IName: Into<Name<'a>>
         {
             IndicesPutAliasRequest {
                 url: IndicesPutAliasUrlParams::IndexName(index.into(), name.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesPutAliasRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesPutAliasRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesPutAliasRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -6122,21 +4974,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatPluginsRequest<'a> {
-        pub fn new() -> CatPluginsRequest<'a> {
+        pub fn new() -> Self {
             CatPluginsRequest { url: CatPluginsUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatPluginsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatPluginsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatPluginsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -6177,51 +5020,37 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct CountPercolateRequest<'a> {
+    pub struct CountPercolateRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> CountPercolateRequest<'a> {
-        pub fn for_index_ty<IIndex, IType, IBody>(index: IIndex,
-                                                  ty: IType,
-                                                  body: IBody)
-                                                  -> CountPercolateRequest<'a>
+    impl<'a, R> CountPercolateRequest<'a, R> {
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  IType: Into<Type<'a>>,
-                  IBody: Into<Body<'a>>
+                  IType: Into<Type<'a>>
         {
             CountPercolateRequest {
                 url: CountPercolateUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index_ty_id<IIndex, IType, IId, IBody>(index: IIndex,
-                                                          ty: IType,
-                                                          id: IId,
-                                                          body: IBody)
-                                                          -> CountPercolateRequest<'a>
+        pub fn for_index_ty_id<IIndex, IType, IId>(index: IIndex,
+                                                   ty: IType,
+                                                   id: IId,
+                                                   body: R)
+                                                   -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>,
-                  IId: Into<Id<'a>>,
-                  IBody: Into<Body<'a>>
+                  IId: Into<Id<'a>>
         {
             CountPercolateRequest {
                 url: CountPercolateUrlParams::IndexTypeId(index.into(), ty.into(), id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CountPercolateRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CountPercolateRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for CountPercolateRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -6249,44 +5078,32 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesUpgradeRequest<'a> {
+    pub struct IndicesUpgradeRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesUpgradeRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesUpgradeRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesUpgradeRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesUpgradeRequest {
                 url: IndicesUpgradeUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesUpgradeRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesUpgradeRequest {
                 url: IndicesUpgradeUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesUpgradeRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesUpgradeRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesUpgradeRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -6313,9 +5130,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesDeleteAliasRequest<'a> {
-        pub fn for_index_name<IIndex, IName>(index: IIndex,
-                                             name: IName)
-                                             -> IndicesDeleteAliasRequest<'a>
+        pub fn for_index_name<IIndex, IName>(index: IIndex, name: IName) -> Self
             where IIndex: Into<Index<'a>>,
                   IName: Into<Name<'a>>
         {
@@ -6324,17 +5139,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesDeleteAliasRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Delete,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesDeleteAliasRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesDeleteAliasRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Delete,
@@ -6358,21 +5164,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatTasksRequest<'a> {
-        pub fn new() -> CatTasksRequest<'a> {
+        pub fn new() -> Self {
             CatTasksRequest { url: CatTasksUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatTasksRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatTasksRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatTasksRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -6407,45 +5204,34 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesRolloverRequest<'a> {
+    pub struct IndicesRolloverRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesRolloverRequest<'a> {
-        pub fn for_alias<IAlias, IBody>(alias: IAlias, body: IBody) -> IndicesRolloverRequest<'a>
-            where IAlias: Into<Alias<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> IndicesRolloverRequest<'a, R> {
+        pub fn for_alias<IAlias>(alias: IAlias, body: R) -> Self
+            where IAlias: Into<Alias<'a>>
         {
             IndicesRolloverRequest {
                 url: IndicesRolloverUrlParams::Alias(alias.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_alias_new_index<IAlias, INewIndex, IBody>(alias: IAlias,
-                                                             new_index: INewIndex,
-                                                             body: IBody)
-                                                             -> IndicesRolloverRequest<'a>
+        pub fn for_alias_new_index<IAlias, INewIndex>(alias: IAlias,
+                                                      new_index: INewIndex,
+                                                      body: R)
+                                                      -> Self
             where IAlias: Into<Alias<'a>>,
-                  INewIndex: Into<NewIndex<'a>>,
-                  IBody: Into<Body<'a>>
+                  INewIndex: Into<NewIndex<'a>>
         {
             IndicesRolloverRequest {
                 url: IndicesRolloverUrlParams::AliasNewIndex(alias.into(), new_index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesRolloverRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesRolloverRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesRolloverRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -6471,38 +5257,26 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct ReindexRethrottleRequest<'a> {
+    pub struct ReindexRethrottleRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> ReindexRethrottleRequest<'a> {
-        pub fn for_task_id<ITaskId, IBody>(task_id: ITaskId,
-                                           body: IBody)
-                                           -> ReindexRethrottleRequest<'a>
-            where ITaskId: Into<TaskId<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> ReindexRethrottleRequest<'a, R> {
+        pub fn for_task_id<ITaskId>(task_id: ITaskId, body: R) -> Self
+            where ITaskId: Into<TaskId<'a>>
         {
             ReindexRethrottleRequest {
                 url: ReindexRethrottleUrlParams::TaskId(task_id.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ReindexRethrottleRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ReindexRethrottleRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for ReindexRethrottleRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
-                body: None,
+                body: Some(self.body),
             }
         }
     }
@@ -6523,34 +5297,22 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SnapshotCreateRepositoryRequest<'a> {
+    pub struct SnapshotCreateRepositoryRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> SnapshotCreateRepositoryRequest<'a> {
-        pub fn for_repository<IRepository, IBody>(repository: IRepository,
-                                                  body: IBody)
-                                                  -> SnapshotCreateRepositoryRequest<'a>
-            where IRepository: Into<Repository<'a>>,
-                  IBody: Into<Body<'a>>
+    impl<'a, R> SnapshotCreateRepositoryRequest<'a, R> {
+        pub fn for_repository<IRepository>(repository: IRepository, body: R) -> Self
+            where IRepository: Into<Repository<'a>>
         {
             SnapshotCreateRepositoryRequest {
                 url: SnapshotCreateRepositoryUrlParams::Repository(repository.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SnapshotCreateRepositoryRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SnapshotCreateRepositoryRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for SnapshotCreateRepositoryRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -6588,14 +5350,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesGetRequest<'a> {
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesGetRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesGetRequest { url: IndicesGetUrlParams::Index(index.into()).url() }
         }
-        pub fn for_index_feature<IIndex, IFeature>(index: IIndex,
-                                                   feature: IFeature)
-                                                   -> IndicesGetRequest<'a>
+        pub fn for_index_feature<IIndex, IFeature>(index: IIndex, feature: IFeature) -> Self
             where IIndex: Into<Index<'a>>,
                   IFeature: Into<Feature<'a>>
         {
@@ -6604,17 +5364,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesGetRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesGetRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesGetRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -6642,40 +5393,28 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesAnalyzeRequest<'a> {
+    pub struct IndicesAnalyzeRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesAnalyzeRequest<'a> {
-        pub fn new<IBody>(body: IBody) -> IndicesAnalyzeRequest<'a>
-            where IBody: Into<Body<'a>>
-        {
+    impl<'a, R> IndicesAnalyzeRequest<'a, R> {
+        pub fn new(body: R) -> Self {
             IndicesAnalyzeRequest {
                 url: IndicesAnalyzeUrlParams::None.url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
-        pub fn for_index<IIndex, IBody>(index: IIndex, body: IBody) -> IndicesAnalyzeRequest<'a>
-            where IIndex: Into<Index<'a>>,
-                  IBody: Into<Body<'a>>
+        pub fn for_index<IIndex>(index: IIndex, body: R) -> Self
+            where IIndex: Into<Index<'a>>
         {
             IndicesAnalyzeRequest {
                 url: IndicesAnalyzeUrlParams::Index(index.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesAnalyzeRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesAnalyzeRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesAnalyzeRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -6706,26 +5445,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatFielddataRequest<'a> {
-        pub fn new() -> CatFielddataRequest<'a> {
+        pub fn new() -> Self {
             CatFielddataRequest { url: CatFielddataUrlParams::None.url() }
         }
-        pub fn for_fields<IFields>(fields: IFields) -> CatFielddataRequest<'a>
+        pub fn for_fields<IFields>(fields: IFields) -> Self
             where IFields: Into<Fields<'a>>
         {
             CatFielddataRequest { url: CatFielddataUrlParams::Fields(fields.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatFielddataRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatFielddataRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatFielddataRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -6757,26 +5487,17 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesSegmentsRequest<'a> {
-        pub fn new() -> IndicesSegmentsRequest<'a> {
+        pub fn new() -> Self {
             IndicesSegmentsRequest { url: IndicesSegmentsUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> IndicesSegmentsRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             IndicesSegmentsRequest { url: IndicesSegmentsUrlParams::Index(index.into()).url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesSegmentsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesSegmentsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesSegmentsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -6803,36 +5524,23 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct IndicesShrinkRequest<'a> {
+    pub struct IndicesShrinkRequest<'a, R> {
         pub url: Url<'a>,
-        pub body: Body<'a>,
+        pub body: Body<R>,
     }
-    impl<'a> IndicesShrinkRequest<'a> {
-        pub fn for_index_target<IIndex, ITarget, IBody>(index: IIndex,
-                                                        target: ITarget,
-                                                        body: IBody)
-                                                        -> IndicesShrinkRequest<'a>
+    impl<'a, R> IndicesShrinkRequest<'a, R> {
+        pub fn for_index_target<IIndex, ITarget>(index: IIndex, target: ITarget, body: R) -> Self
             where IIndex: Into<Index<'a>>,
-                  ITarget: Into<Target<'a>>,
-                  IBody: Into<Body<'a>>
+                  ITarget: Into<Target<'a>>
         {
             IndicesShrinkRequest {
                 url: IndicesShrinkUrlParams::IndexTarget(index.into(), target.into()).url(),
-                body: body.into(),
+                body: Body::new(body),
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesShrinkRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Post,
-                body: Some(self.body.as_ref().into()),
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesShrinkRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a, R> Into<HttpRequest<'a, R>> for IndicesShrinkRequest<'a, R> {
+        fn into(self) -> HttpRequest<'a, R> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Post,
@@ -6856,21 +5564,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> TasksListRequest<'a> {
-        pub fn new() -> TasksListRequest<'a> {
+        pub fn new() -> Self {
             TasksListRequest { url: TasksListUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a TasksListRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for TasksListRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for TasksListRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -6894,21 +5593,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> CatMasterRequest<'a> {
-        pub fn new() -> CatMasterRequest<'a> {
+        pub fn new() -> Self {
             CatMasterRequest { url: CatMasterUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a CatMasterRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for CatMasterRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for CatMasterRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -6939,7 +5629,7 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> IndicesExistsTypeRequest<'a> {
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType) -> IndicesExistsTypeRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
@@ -6948,17 +5638,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a IndicesExistsTypeRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Head,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for IndicesExistsTypeRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for IndicesExistsTypeRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Head,
@@ -6982,21 +5663,12 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> ClusterGetSettingsRequest<'a> {
-        pub fn new() -> ClusterGetSettingsRequest<'a> {
+        pub fn new() -> Self {
             ClusterGetSettingsRequest { url: ClusterGetSettingsUrlParams::None.url() }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a ClusterGetSettingsRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for ClusterGetSettingsRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for ClusterGetSettingsRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -7043,22 +5715,20 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> NodesInfoRequest<'a> {
-        pub fn new() -> NodesInfoRequest<'a> {
+        pub fn new() -> Self {
             NodesInfoRequest { url: NodesInfoUrlParams::None.url() }
         }
-        pub fn for_metric<IMetric>(metric: IMetric) -> NodesInfoRequest<'a>
+        pub fn for_metric<IMetric>(metric: IMetric) -> Self
             where IMetric: Into<Metric<'a>>
         {
             NodesInfoRequest { url: NodesInfoUrlParams::Metric(metric.into()).url() }
         }
-        pub fn for_node_id<INodeId>(node_id: INodeId) -> NodesInfoRequest<'a>
+        pub fn for_node_id<INodeId>(node_id: INodeId) -> Self
             where INodeId: Into<NodeId<'a>>
         {
             NodesInfoRequest { url: NodesInfoUrlParams::NodeId(node_id.into()).url() }
         }
-        pub fn for_node_id_metric<INodeId, IMetric>(node_id: INodeId,
-                                                    metric: IMetric)
-                                                    -> NodesInfoRequest<'a>
+        pub fn for_node_id_metric<INodeId, IMetric>(node_id: INodeId, metric: IMetric) -> Self
             where INodeId: Into<NodeId<'a>>,
                   IMetric: Into<Metric<'a>>
         {
@@ -7067,17 +5737,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a NodesInfoRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for NodesInfoRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for NodesInfoRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -7119,15 +5780,15 @@ pub mod endpoints {
         pub url: Url<'a>,
     }
     impl<'a> SimpleSearchRequest<'a> {
-        pub fn new() -> SimpleSearchRequest<'a> {
+        pub fn new() -> Self {
             SimpleSearchRequest { url: SimpleSearchUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex) -> SimpleSearchRequest<'a>
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
             SimpleSearchRequest { url: SimpleSearchUrlParams::Index(index.into()).url() }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType) -> SimpleSearchRequest<'a>
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
@@ -7136,17 +5797,8 @@ pub mod endpoints {
             }
         }
     }
-    impl<'a, 'b: 'a> Into<HttpRequest<'a>> for &'a SimpleSearchRequest<'b> {
-        fn into(self) -> HttpRequest<'a> {
-            HttpRequest {
-                url: self.url.as_ref().into(),
-                method: HttpMethod::Get,
-                body: None,
-            }
-        }
-    }
-    impl<'a> Into<HttpRequest<'a>> for SimpleSearchRequest<'a> {
-        fn into(self) -> HttpRequest<'a> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for SimpleSearchRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
@@ -7179,48 +5831,33 @@ pub mod http {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct Body<'a>(Cow<'a, [u8]>);
-    impl<'a> From<Vec<u8>> for Body<'a> {
-        fn from(value: Vec<u8>) -> Body<'a> {
-            Body(Cow::Owned(value))
+    pub struct Body<R>(R);
+    pub type DefaultBody = &'static [u8];
+    impl<R> Body<R> {
+        pub fn new(inner: R) -> Self {
+            Body(inner)
         }
-    }
-    impl<'a> From<&'a [u8]> for Body<'a> {
-        fn from(value: &'a [u8]) -> Body<'a> {
-            Body(Cow::Borrowed(value))
-        }
-    }
-    impl<'a> From<&'a str> for Body<'a> {
-        fn from(value: &'a str) -> Body<'a> {
-            Body(Cow::Borrowed(value.as_bytes()))
-        }
-    }
-    impl<'a> From<String> for Body<'a> {
-        fn from(value: String) -> Body<'a> {
-            Body(Cow::Owned(value.into()))
-        }
-    }
-    impl<'a> Deref for Body<'a> {
-        type Target = Cow<'a, [u8]>;
-        fn deref(&self) -> &Cow<'a, [u8]> {
-            &self.0
-        }
-    }
-    impl<'a> Body<'a> {
-        pub fn into_inner(self) -> Cow<'a, [u8]> {
+        pub fn into_inner(self) -> R {
             self.0
         }
     }
-    impl<'a> Body<'a> {
+    impl Body<DefaultBody> {
         pub fn none() -> Self {
-            Body(Cow::Borrowed(&[]))
+            Body(&[])
+        }
+    }
+    impl<R> AsRef<[u8]> for Body<R>
+        where R: AsRef<[u8]>
+    {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_ref()
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct HttpRequest<'a> {
+    pub struct HttpRequest<'a, R> {
         pub url: Url<'a>,
         pub method: HttpMethod,
-        pub body: Option<Body<'a>>,
+        pub body: Option<Body<R>>,
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
     pub enum HttpMethod {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! ```
 //! # use elastic_requests::*;
-//! fn takes_req<'a, I: Into<HttpRequest<'a>>>(req: I) {
+//! fn takes_req<'a, I: Into<HttpRequest<'a, B>>, B: AsRef<[u8]>>(req: I) {
 //!     let req = req.into();
 //!
 //!     // do something with the HttpRequest
@@ -114,9 +114,9 @@ mod tests {
     use std::thread;
     use super::*;
 
-    fn do_something_with_request<'a, I: Into<HttpRequest<'a>>>(_: I) {}
+    fn do_something_with_request<'a, I: Into<HttpRequest<'a, B>>, B>(_: I) {}
 
-    fn do_something_with_static_request<I: Into<HttpRequest<'static>>>
+    fn do_something_with_static_request<I: Into<HttpRequest<'static, B>>, B: 'static + Send>
         (req: I)
          -> thread::JoinHandle<()> {
         let req = req.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! There's also a more general `HttpRequest` type that all requests can be converted into.
 //!
 //! Request types are generic over the body buffer, `B`.
-//! This gives clients a lot of flexibility when designing APIs,
+//! This gives you a lot of flexibility when designing APIs,
 //! but you should be careful to ensure the `B` is bound appropriately.
 //! 
 //! # Supported Versions
@@ -121,9 +121,9 @@ mod tests {
     use std::thread;
     use super::*;
 
-    fn do_something_with_request<'a, I: Into<HttpRequest<'a, B>>, B>(_: I) {}
+    fn do_something_with_request<'a, I: Into<HttpRequest<'a, B>>, B: AsRef<[u8]>>(_: I) {}
 
-    fn do_something_with_static_request<I: Into<HttpRequest<'static, B>>, B: 'static + Send>
+    fn do_something_with_static_request<I: Into<HttpRequest<'static, B>>, B: 'static + AsRef<[u8]> + Send>
         (req: I)
          -> thread::JoinHandle<()> {
         let req = req.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@
 //! A `struct` is provided for each endpoint that works with borrowed or owned data.
 //! There's also a more general `HttpRequest` type that all requests can be converted into.
 //!
+//! Request types are generic over the body buffer, `B`.
+//! This gives clients a lot of flexibility when designing APIs,
+//! but you should be careful to ensure the `B` is bound appropriately.
+//! 
 //! # Supported Versions
 //!
 //!  `elastic_requests` | Elasticsearch
@@ -49,18 +53,21 @@
 //! assert_eq!("/test_index/_search", req.url.as_ref());
 //! ```
 //!
-//! All request types can be converted into a more general `HttpRequest`:
+//! All request types can be converted into a more general `HttpRequest`.
+//! In this example, `takes_req` accepts anything that can be converted into
+//! a `HttpRequest` where the body buffer is `AsRef<[u8]>`:
 //!
 //! ```
 //! # use elastic_requests::*;
 //! fn takes_req<'a, I: Into<HttpRequest<'a, B>>, B: AsRef<[u8]>>(req: I) {
 //!     let req = req.into();
+//!     let body = req.body.as_ref();
 //!
-//!     // do something with the HttpRequest
+//!     // do something with the request
 //! }
 //!
 //! takes_req(PingRequest::new());
-//! takes_req(SearchRequest::for_index("test_index", Body::none()));
+//! takes_req(SearchRequest::for_index("test_index", empty_body()));
 //! ```
 //!
 //! # Why are these docs useless?
@@ -144,7 +151,7 @@ mod tests {
 
     #[test]
     fn it_works_static() {
-        let req = SearchRequest::for_index_ty(String::from("test_index"), "test_ty", Body::none());
+        let req = SearchRequest::for_index_ty(String::from("test_index"), "test_ty", empty_body());
 
         do_something_with_static_request(req).join().unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,13 @@ mod tests {
 
         assert_eq!("/test_index/test_ty/_search", *req.url);
 
-        do_something_with_request(&req);
+        do_something_with_request(req);
+    }
+
+    #[test]
+    fn it_works_no_body() {
+        let req = PingRequest::new();
+
         do_something_with_request(req);
     }
 


### PR DESCRIPTION
Closes #20 

This makes the `Body` type a simple wrapper around some type (it probably doesn't even really need to exist anymore, but can stick around for now). That means other libraries can accept body types with different implementations, like `Bytes`.