### PR TITLE
Use GET for ping request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_requests"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Code generated request types for the Elasticsearch REST API."

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -158,6 +158,7 @@ impl CustomEndpoints for Vec<(String, Endpoint)> {
                     "search" => {
                         let mut simple_search_endpoint = endpoint.clone();
                         simple_search_endpoint.methods = vec![HttpMethod::Get];
+                        simple_search_endpoint.body = None;
 
                         endpoints.push((String::from("simple_search"), simple_search_endpoint));
                         endpoints.push((String::from("search"), endpoint));

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -42,7 +42,8 @@ fn main() {
 
     let mut endpoints = from_dir(dir)
         .expect("Couldn't parse the REST API spec")
-        .add_simple_search();
+        .add_simple_search()
+        .add_get_ping_req();
 
     endpoints = endpoints    
         .into_iter()
@@ -144,29 +145,46 @@ fn dedup_urls(endpoint: (String, Endpoint)) -> (String, Endpoint) {
     (name, endpoint)
 }
 
-trait AddSimpleSearch {
+trait CustomEndpoints {
     fn add_simple_search(self) -> Self;
+    fn add_get_ping_req(self) -> Self;
 }
 
-impl AddSimpleSearch for Vec<(String, Endpoint)> {
-    fn add_simple_search(mut self) -> Vec<(String, Endpoint)> {
-        let mut endpoint = {
-            let &(_, ref endpoint) = self
-                .iter()
-                .find(|ref endpoint| endpoint.0 == "search")
-                .unwrap();
+impl CustomEndpoints for Vec<(String, Endpoint)> {
+    fn add_simple_search(self) -> Vec<(String, Endpoint)> {
+        self.into_iter()
+            .fold(vec![], |mut endpoints, (name, endpoint)| {
+                match name.as_ref() {
+                    "search" => {
+                        let mut simple_search_endpoint = endpoint.clone();
+                        simple_search_endpoint.methods = vec![HttpMethod::Get];
 
-            endpoint.clone()
-        };
+                        endpoints.push((String::from("simple_search"), simple_search_endpoint));
+                        endpoints.push((String::from("search"), endpoint));
+                    },
+                    _ => endpoints.push((name, endpoint))
+                }
 
-        let name = String::from("simple_search");
+                endpoints
+            })
+    }
 
-        endpoint.methods = vec![HttpMethod::Get];
-        endpoint.body = None;
+    fn add_get_ping_req(self) -> Vec<(String, Endpoint)> {
+        self.into_iter()
+            .fold(vec![], |mut endpoints, (name, endpoint)| {
+                match name.as_ref() {
+                    "ping" => {
+                        let mut get_endpoint = endpoint.clone();
+                        get_endpoint.methods = vec![HttpMethod::Get];
 
-        self.push((name, endpoint));
+                        endpoints.push((String::from("ping"), get_endpoint));
+                        endpoints.push((String::from("ping_head"), endpoint));
+                    },
+                    _ => endpoints.push((name, endpoint))
+                }
 
-        self
+                endpoints
+            })
     }
 }
 

--- a/src/genned.rs
+++ b/src/genned.rs
@@ -1719,41 +1719,33 @@ pub mod endpoints {
         }
     }
     # [ derive ( Debug , PartialEq , Clone ) ]
-    pub struct SimpleSearchRequest<'a, B> {
+    pub struct SimpleSearchRequest<'a> {
         pub url: Url<'a>,
-        pub body: B,
     }
-    impl<'a, B> SimpleSearchRequest<'a, B> {
-        pub fn new(body: B) -> Self {
-            SimpleSearchRequest {
-                url: SimpleSearchUrlParams::None.url(),
-                body: body,
-            }
+    impl<'a> SimpleSearchRequest<'a> {
+        pub fn new() -> Self {
+            SimpleSearchRequest { url: SimpleSearchUrlParams::None.url() }
         }
-        pub fn for_index<IIndex>(index: IIndex, body: B) -> Self
+        pub fn for_index<IIndex>(index: IIndex) -> Self
             where IIndex: Into<Index<'a>>
         {
-            SimpleSearchRequest {
-                url: SimpleSearchUrlParams::Index(index.into()).url(),
-                body: body,
-            }
+            SimpleSearchRequest { url: SimpleSearchUrlParams::Index(index.into()).url() }
         }
-        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType, body: B) -> Self
+        pub fn for_index_ty<IIndex, IType>(index: IIndex, ty: IType) -> Self
             where IIndex: Into<Index<'a>>,
                   IType: Into<Type<'a>>
         {
             SimpleSearchRequest {
                 url: SimpleSearchUrlParams::IndexType(index.into(), ty.into()).url(),
-                body: body,
             }
         }
     }
-    impl<'a, B> Into<HttpRequest<'a, B>> for SimpleSearchRequest<'a, B> {
-        fn into(self) -> HttpRequest<'a, B> {
+    impl<'a> Into<HttpRequest<'a, DefaultBody>> for SimpleSearchRequest<'a> {
+        fn into(self) -> HttpRequest<'a, DefaultBody> {
             HttpRequest {
                 url: self.url,
                 method: HttpMethod::Get,
-                body: Some(self.body),
+                body: None,
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! Request types are generic over the body buffer, `B`.
 //! This gives you a lot of flexibility when designing APIs,
 //! but you should be careful to ensure the `B` is bound appropriately.
-//! 
+//!
 //! # Supported Versions
 //!
 //!  `elastic_requests` | Elasticsearch
@@ -123,7 +123,8 @@ mod tests {
 
     fn do_something_with_request<'a, I: Into<HttpRequest<'a, B>>, B: AsRef<[u8]>>(_: I) {}
 
-    fn do_something_with_static_request<I: Into<HttpRequest<'static, B>>, B: 'static + AsRef<[u8]> + Send>
+    fn do_something_with_static_request<I: Into<HttpRequest<'static, B>>,
+                                        B: 'static + AsRef<[u8]> + Send>
         (req: I)
          -> thread::JoinHandle<()> {
         let req = req.into();


### PR DESCRIPTION
Adds a new `PingHeadRequest` type for doing a quick `HEAD` cluster ping, and uses `GET` for `PingRequest` so that it returns cluster metadata.