### PR TITLE
Convert integers to Id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_requests"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Code generated request types for the Elasticsearch REST API."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_requests"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Code generated request types for the Elasticsearch REST API."

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -270,6 +270,9 @@ fn params_mod(tokens: &mut Tokens, derives: Tokens, params_to_emit: BTreeMap<Str
     tokens.append(uses.to_string());
     tokens.append("\n\n");
 
+    tokens.append(r#"include!("genned.params.rs");"#);
+    tokens.append("\n\n");
+
     let params_to_emit = params_to_emit.iter()
         .filter(|&(_, is_emitted)| *is_emitted);
 

--- a/src/genned.params.rs
+++ b/src/genned.params.rs
@@ -1,0 +1,16 @@
+macro_rules! impl_from_num_for_id {
+    ($num:ty) => (
+        impl<'a> From<$num> for Id<'a> {
+            fn from(value: $num) -> Id<'a> {
+                Id::from(value.to_string())
+            }
+        }
+    )
+}
+
+impl_from_num_for_id!(u32);
+impl_from_num_for_id!(u64);
+impl_from_num_for_id!(usize);
+impl_from_num_for_id!(i32);
+impl_from_num_for_id!(i64);
+impl_from_num_for_id!(isize);

--- a/src/genned.rs
+++ b/src/genned.rs
@@ -5889,6 +5889,8 @@ pub mod http {
 pub mod params {
     use std::borrow::Cow;
 
+    include!("genned.params.rs");
+
     # [ derive ( Debug , PartialEq , Clone ) ]
     pub struct Alias<'a>(pub Cow<'a, str>);
     pub fn alias<'a, I>(value: I) -> Alias<'a>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,4 +156,13 @@ mod tests {
 
         do_something_with_static_request(req).join().unwrap();
     }
+
+    #[test]
+    fn id_from_number() {
+        let ids = vec![Id::from(1i32), Id::from(1u32), Id::from(1i64), Id::from(1u64), Id::from(1isize), Id::from(1usize)];
+
+        for id in ids {
+            assert_eq!("1", &*id);
+        }
+    }
 }


### PR DESCRIPTION
Closes #30

Uses `include!` so we can add new internal implementations for things.